### PR TITLE
Add option to specify deviceId

### DIFF
--- a/MMM-MotionDetector.js
+++ b/MMM-MotionDetector.js
@@ -3,7 +3,8 @@ Module.register("MMM-MotionDetector", {
   defaults: {
     captureIntervalTime: 1000, // 1 second
     scoreThreshold: 20,
-    timeout: 120000, // 2 minutes
+    timeout: 120000, // 2 minutes,
+  	deviceId: null
   },
 
   lastScoreDetected: null,
@@ -66,6 +67,7 @@ Module.register("MMM-MotionDetector", {
 
     DiffCamEngine.init({
       video: video,
+	  deviceId: this.config.deviceId,
       captureIntervalTime: this.config.captureIntervalTime,
       motionCanvas: canvas,
       initSuccessCallback: () => {

--- a/diff-cam-engine.js
+++ b/diff-cam-engine.js
@@ -1,6 +1,7 @@
 const DiffCamEngine = (function () {
   let stream; // stream obtained from webcam
   let video; // shows stream
+  let deviceId;
   let captureCanvas; // internal canvas for capturing full images from video
   let captureContext; // context for capture canvas
   let diffCanvas; // internal canvas for diffing downscaled captures
@@ -39,6 +40,7 @@ const DiffCamEngine = (function () {
 
     // incoming options with defaults
     video = options.video || document.createElement("video");
+    deviceId = options.deviceId || null,
     motionCanvas = options.motionCanvas || document.createElement("canvas");
     captureIntervalTime = options.captureIntervalTime || 100;
     captureWidth = options.captureWidth || 640;
@@ -105,9 +107,12 @@ const DiffCamEngine = (function () {
       };
     }
 
+    // check if a special deviceId was passed as an option
+    const userMediaOptions = deviceId ? { video: { deviceId: {exact: deviceId } } } : { video: true };
+
     // request webcam
     navigator.mediaDevices
-      .getUserMedia({ video: true })
+      .getUserMedia(userMediaOptions)
       .then(function (localMediaStream) {
         // Older browsers may not have srcObject
         if ("srcObject" in video) {


### PR DESCRIPTION
Fixes #47 by adding new option to specify deviceId of camera to be used. 

DeviceId can be found by calling navigator.mediaDevices.enumerateDevices() in the brwoser where thi smodule is running