### PR TITLE
fix: remove dead MOTION_DETECTED socket notification

### DIFF
--- a/MMM-MotionDetector.js
+++ b/MMM-MotionDetector.js
@@ -87,7 +87,6 @@ Module.register("MMM-MotionDetector", {
         );
         if (hasMotion) {
           Log.info(`Motion detected, score: ${score}`);
-          this.sendSocketNotification("MOTION_DETECTED", { score: score });
           this.sendNotification("MOTION_DETECTED", { score: score });
           if (this.poweredOff) {
             Log.info(`Percentage of uptime powered off:  ${this.percentagePoweredOff}`);

--- a/tests/module.test.js
+++ b/tests/module.test.js
@@ -4,16 +4,23 @@ const { loadModule, setLastMotionAge } = require("./module-mock");
 
 describe("MMM-MotionDetector", () => {
   describe("motion detected", () => {
-    it("announces motion on both the socket and the module bus", () => {
+    it("announces motion on the module bus", () => {
       const { module, capture } = loadModule();
 
       capture({ score: 42, hasMotion: true });
 
-      assert.deepStrictEqual(module.notifications, [
-        ["socket", "MOTION_DETECTED", { score: 42 }],
-        ["notification", "MOTION_DETECTED", { score: 42 }],
-      ]);
+      assert.deepStrictEqual(module.notifications, [["notification", "MOTION_DETECTED", { score: 42 }]]);
       assert.strictEqual(module.lastScoreDetected, 42);
+    });
+
+    it("does not send MOTION_DETECTED over the socket, the node helper has no handler for it", () => {
+      const { module, capture } = loadModule();
+
+      capture({ score: 42, hasMotion: true });
+
+      assert.ok(
+        !module.notifications.some(([bus, notification]) => bus === "socket" && notification === "MOTION_DETECTED")
+      );
     });
 
     it("does not activate the monitor when it is already on", () => {


### PR DESCRIPTION
## Summary
- The frontend sent `sendSocketNotification("MOTION_DETECTED", ...)` to node_helper.js on every motion event.
- node_helper.js's `socketNotificationReceived` never handled that notification type, so it was a silent no-op.
- Removed the dead send; the `sendNotification` broadcast to other MagicMirror modules (which is what actually matters) is unchanged.

## Test plan
- [ ] `npm run lint` passes (ran locally, clean)
- [ ] Confirm other modules still receive `MOTION_DETECTED` via `notificationReceived`