### PR TITLE
refactor: remove unnecessary module-level coords variable

### DIFF
--- a/diff-cam-engine.js
+++ b/diff-cam-engine.js
@@ -29,8 +29,6 @@ window.DiffCamEngine = (function () {
   let imageMimeType; // string e.g. "image/jpeg", "image/png"
   let jpegQuality; // imageMimeType:"image/jpeg" quality value between 0 and 1
 
-  let coords;
-
   /**
    *
    * @param options
@@ -237,14 +235,14 @@ window.DiffCamEngine = (function () {
 
       if (pixelDiff >= pixelDiffThreshold) {
         score++;
-        coords = calculateCoordinates(i / 4);
+        const { x, y } = calculateCoordinates(i / 4);
 
         if (includeMotionBox) {
-          motionBox = calculateMotionBox(motionBox, coords.x, coords.y);
+          motionBox = calculateMotionBox(motionBox, x, y);
         }
 
         if (includeMotionPixels) {
-          motionPixels = calculateMotionPixels(motionPixels, coords.x, coords.y);
+          motionPixels = calculateMotionPixels(motionPixels, x, y);
         }
       }
     }
@@ -278,8 +276,8 @@ window.DiffCamEngine = (function () {
   function calculateMotionBox(currentMotionBox, x, y) {
     // init motion box on demand
     let motionBox = currentMotionBox || {
-      x: { min: coords.x, max: x },
-      y: { min: coords.y, max: y },
+      x: { min: x, max: x },
+      y: { min: y, max: y },
     };
 
     motionBox.x.min = Math.min(motionBox.x.min, x);

--- a/tests/diff-cam-engine-motion-box.test.js
+++ b/tests/diff-cam-engine-motion-box.test.js
@@ -1,0 +1,90 @@
+const assert = require("node:assert");
+const { describe, it } = require("node:test");
+const { loadEngine, frameWithMotionAt } = require("./diff-cam-engine-mock");
+
+const MOVING_PIXELS = [
+  { x: 5, y: 3 },
+  { x: 20, y: 10 },
+  { x: 12, y: 40 },
+];
+
+/**
+ * Run one diffed capture over a frame with motion at the given coordinates.
+ * @param pixels list of {x, y} coordinates that should move
+ * @param options extra options passed to DiffCamEngine.init
+ * @returns {Promise<object>} the capture result handed to captureCallback
+ */
+async function captureAt(pixels, options = {}) {
+  const engine = await loadEngine({
+    frames: [frameWithMotionAt([]), frameWithMotionAt(pixels)],
+    init: { includeMotionBox: true, scoreThreshold: 1, ...options },
+  });
+
+  engine.startStreaming();
+  engine.tick(); // primes the previous frame, nothing is diffed yet
+  engine.tick();
+
+  return engine.captures[0];
+}
+
+describe("DiffCamEngine motion box", () => {
+  it("spans every moving pixel", async () => {
+    const capture = await captureAt(MOVING_PIXELS);
+
+    assert.strictEqual(capture.score, MOVING_PIXELS.length);
+    assert.deepStrictEqual(capture.motionBox, {
+      x: { min: 5, max: 20 },
+      y: { min: 3, max: 40 },
+    });
+  });
+
+  it("collapses to a single point for one moving pixel", async () => {
+    const engine = await loadEngine({
+      frames: [frameWithMotionAt([]), frameWithMotionAt([{ x: 7, y: 9 }])],
+      init: { includeMotionBox: true },
+    });
+
+    // init reads scoreThreshold with a || default, so a zero passed there would
+    // silently become 16, the setter is the only way to get a threshold of zero
+    engine.engine.setScoreThreshold(0);
+    engine.startStreaming();
+    engine.tick();
+    engine.tick();
+
+    assert.deepStrictEqual(engine.captures[0].motionBox, {
+      x: { min: 7, max: 7 },
+      y: { min: 9, max: 9 },
+    });
+  });
+
+  it("does not leak coordinates between captures", async () => {
+    const engine = await loadEngine({
+      frames: [frameWithMotionAt([]), frameWithMotionAt([{ x: 60, y: 45 }]), frameWithMotionAt([{ x: 1, y: 2 }])],
+      init: { includeMotionBox: true },
+    });
+
+    engine.engine.setScoreThreshold(0);
+    engine.startStreaming();
+    engine.tick();
+    engine.tick();
+    engine.tick();
+
+    assert.deepStrictEqual(engine.captures[0].motionBox, {
+      x: { min: 60, max: 60 },
+      y: { min: 45, max: 45 },
+    });
+    assert.deepStrictEqual(engine.captures[1].motionBox, {
+      x: { min: 1, max: 1 },
+      y: { min: 2, max: 2 },
+    });
+  });
+
+  it("reports the moving pixels when asked", async () => {
+    const capture = await captureAt(MOVING_PIXELS, { includeMotionPixels: true });
+
+    for (const { x, y } of MOVING_PIXELS) {
+      assert.strictEqual(capture.checkMotionPixel(x, y), true, `expected motion at ${x},${y}`);
+    }
+    assert.ok(!capture.checkMotionPixel(0, 0));
+  });
+});


### PR DESCRIPTION
## Summary
- `calculateMotionBox(currentMotionBox, x, y)` reached back into a module-level `coords` closure for its box-init case, even though it's always called with the same `x`/`y` values it already receives as parameters (assigned from `calculateCoordinates()` right before the call).
- Removed the `coords` global and used the local `x`/`y` values directly. No behavior change.

## Test plan
- [ ] `npm run lint` passes (ran locally, clean)
- [ ] Manually verify motion box drawing is unchanged

---

**Update:** rebased onto `develop` after #97 and #99 merged. The shared mock now comes from `develop` and these tests live in their own file, so there are no merge conflicts left.