### PR TITLE
fix: validate platform config before building command script path

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -3,12 +3,18 @@ const exec = require("util").promisify(require("child_process").exec);
 const Log = require("../../js/logger");
 const path = require("path");
 
+const VALID_PLATFORMS = ["x11", "cec", "labwc", "mac-arm", "mac-intel"];
+
 module.exports = NodeHelper.create({
 
   /**
    * @param platform
    */
   initMonitor (platform) {
+    if (!VALID_PLATFORMS.includes(platform)) {
+      Log.error(`unknown platform "${platform}", must be one of: ${VALID_PLATFORMS.join(", ")}.`);
+      return;
+    }
     this.platform = platform;
     this.activateMonitor()
       .then(() => Log.info("monitor has been initially activated."))

--- a/tests/node-helper-mock.js
+++ b/tests/node-helper-mock.js
@@ -1,0 +1,67 @@
+const path = require("node:path");
+const Module = require("node:module");
+
+const HELPER_PATH = path.join(__dirname, "..", "node_helper.js");
+
+/**
+ * Load node_helper.js outside of a MagicMirror checkout.
+ *
+ * The helper pulls in "node_helper" and "../../js/logger", neither of which
+ * exists when this repository is checked out on its own, and it shells out via
+ * child_process. All three are swapped out through a temporary require hook.
+ * @param options.exec handler receiving the command string, returns {stdout, stderr} or throws
+ * @returns {{helper: object, commands: string[], logs: object}}
+ */
+function loadNodeHelper({ exec } = {}) {
+  const commands = [];
+  const logs = { error: [], info: [] };
+  const execHandler = exec || (() => ({ stdout: "", stderr: "" }));
+
+  const fakeChildProcess = {
+    exec: (command, callback) => {
+      commands.push(command);
+      try {
+        const { stdout = "", stderr = "" } = execHandler(command) || {};
+        callback(null, { stdout, stderr });
+      } catch (error) {
+        callback(error);
+      }
+    },
+  };
+
+  const stubs = {
+    node_helper: { create: (definition) => definition },
+    "../../js/logger": {
+      error: (message) => logs.error.push(message),
+      info: (message) => logs.info.push(message),
+    },
+    child_process: fakeChildProcess,
+    "node:child_process": fakeChildProcess,
+  };
+
+  const originalLoad = Module._load;
+  Module._load = function (request, parent, isMain) {
+    if (Object.hasOwn(stubs, request)) {
+      return stubs[request];
+    }
+    return originalLoad.call(this, request, parent, isMain);
+  };
+
+  try {
+    delete require.cache[require.resolve(HELPER_PATH)];
+    const helper = require(HELPER_PATH);
+    return { helper: Object.create(helper), commands, logs };
+  } finally {
+    Module._load = originalLoad;
+  }
+}
+
+/**
+ * Wait for the promise chains the helper kicks off without awaiting.
+ * @returns {Promise<void>}
+ */
+function flush() {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+module.exports = { loadNodeHelper, flush };

--- a/tests/node-helper.test.js
+++ b/tests/node-helper.test.js
@@ -1,0 +1,60 @@
+const assert = require("node:assert");
+const { describe, it } = require("node:test");
+const { loadNodeHelper, flush } = require("./node-helper-mock");
+
+const PLATFORMS = ["x11", "cec", "labwc", "mac-arm", "mac-intel"];
+
+describe("node_helper", () => {
+  describe("platform validation", () => {
+    for (const platform of PLATFORMS) {
+      it(`accepts the ${platform} platform`, async () => {
+        const { helper, commands, logs } = loadNodeHelper();
+
+        helper.initMonitor(platform);
+        await flush();
+
+        assert.strictEqual(helper.platform, platform);
+        assert.deepStrictEqual(logs.error, []);
+        assert.ok(commands.some((command) => command.includes(`monitor-commands-${platform}.sh`)));
+      });
+    }
+
+    it("rejects an unknown platform without shelling out", async () => {
+      const { helper, commands, logs } = loadNodeHelper();
+
+      helper.initMonitor("wayland");
+      await flush();
+
+      assert.deepStrictEqual(commands, []);
+      assert.strictEqual(logs.error.length, 1);
+      assert.match(logs.error[0], /unknown platform/);
+    });
+
+    it("rejects a platform that would traverse out of the module directory", async () => {
+      const { helper, commands, logs } = loadNodeHelper();
+
+      helper.initMonitor("../../../../etc/passwd");
+      await flush();
+
+      assert.deepStrictEqual(commands, []);
+      assert.strictEqual(logs.error.length, 1);
+      assert.strictEqual(helper.platform, undefined);
+    });
+  });
+
+  describe("script paths", () => {
+    it("falls back to x11 when no platform was set", () => {
+      const { helper } = loadNodeHelper();
+
+      assert.ok(helper.getCommandScript().endsWith("monitor-commands-x11.sh"));
+    });
+
+    it("builds the script path from the configured platform", () => {
+      const { helper } = loadNodeHelper();
+
+      helper.platform = "cec";
+
+      assert.ok(helper.getCommandScript().endsWith("monitor-commands-cec.sh"));
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- `config.platform` was interpolated directly into a script filename (`monitor-commands-${platform}.sh`) and shell-executed without validation.
- A typo'd or unknown platform value silently failed at `exec` time with a confusing error instead of a clear one.
- Added a whitelist (`x11`, `cec`, `labwc`, `mac-arm`, `mac-intel`) checked in `initMonitor`, logging a clear error listing valid options when the configured platform doesn't match.

## Test plan
- [ ] `npm run lint` passes (ran locally, clean)
- [ ] Set an invalid `platform` in config and confirm a clear error is logged instead of an exec failure
- [ ] Confirm each valid platform still initializes correctly