### PR TITLE
refactor: skip redundant isMonitorOn status check before toggling

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -30,35 +30,21 @@ module.exports = NodeHelper.create({
   },
 
   /**
-   *
+   * Turns the monitor on. The underlying scripts are idempotent, so no
+   * status check is needed beforehand.
    */
   async activateMonitor () {
     const scriptPath = this.getCommandScript();
-    const isMonitorOn = await this.isMonitorOn();
-    if (!isMonitorOn) {
-      await exec(`bash ${scriptPath} on`);
-    }
+    await exec(`bash ${scriptPath} on`);
   },
 
   /**
-   *
+   * Turns the monitor off. The underlying scripts are idempotent, so no
+   * status check is needed beforehand.
    */
   async deactivateMonitor () {
     const scriptPath = this.getCommandScript();
-    const isMonitorOn = await this.isMonitorOn();
-    if (isMonitorOn) {
-      await exec(`bash ${scriptPath} off`);
-    }
-  },
-
-  /**
-   * @returns {Promise<boolean>}
-   */
-  async isMonitorOn () {
-    const scriptPath = this.getCommandScript();
-    const result = await exec(`bash ${scriptPath} status`);
-    Log.info(`monitor is currently ${ result.stdout.trim()}.`);
-    return result.stdout.trim() === "ON";
+    await exec(`bash ${scriptPath} off`);
   },
 
   /**

--- a/tests/node-helper-toggling.test.js
+++ b/tests/node-helper-toggling.test.js
@@ -1,0 +1,117 @@
+const assert = require("node:assert");
+const { describe, it } = require("node:test");
+const { loadNodeHelper, flush } = require("./node-helper-mock");
+
+describe("node_helper", () => {
+  describe("monitor toggling", () => {
+    it("turns the monitor on with a single command", async () => {
+      const { helper, commands } = loadNodeHelper();
+
+      helper.platform = "x11";
+      await helper.activateMonitor();
+
+      assert.deepStrictEqual(commands.length, 1);
+      assert.match(commands[0], /monitor-commands-x11\.sh on$/);
+    });
+
+    it("turns the monitor off with a single command", async () => {
+      const { helper, commands } = loadNodeHelper();
+
+      helper.platform = "x11";
+      await helper.deactivateMonitor();
+
+      assert.deepStrictEqual(commands.length, 1);
+      assert.match(commands[0], /monitor-commands-x11\.sh off$/);
+    });
+
+    it("never queries the status, the scripts are idempotent", async () => {
+      const { helper, commands } = loadNodeHelper();
+
+      helper.platform = "x11";
+      await helper.activateMonitor();
+      await helper.deactivateMonitor();
+
+      assert.ok(!commands.some((command) => command.endsWith("status")));
+    });
+
+    it("turns the monitor on even when it is already on", async () => {
+      // the old status check skipped the call in this case, which left the
+      // monitor asleep whenever the status script misreported
+      const { helper, commands } = loadNodeHelper({ exec: () => ({ stdout: "ON" }) });
+
+      helper.platform = "x11";
+      await helper.activateMonitor();
+
+      assert.match(commands[0], /sh on$/);
+    });
+
+    it("propagates a failing script", async () => {
+      const { helper } = loadNodeHelper({
+        exec: () => {
+          throw new Error("vcgencmd not found");
+        },
+      });
+
+      helper.platform = "x11";
+
+      await assert.rejects(() => helper.activateMonitor(), /vcgencmd not found/);
+    });
+  });
+
+  describe("socket notifications", () => {
+    it("activates the monitor on ACTIVATE_MONITOR", async () => {
+      const { helper, commands } = loadNodeHelper();
+
+      helper.platform = "x11";
+      helper.socketNotificationReceived("ACTIVATE_MONITOR");
+      await flush();
+
+      assert.deepStrictEqual(commands.length, 1);
+      assert.match(commands[0], /sh on$/);
+    });
+
+    it("deactivates the monitor on DEACTIVATE_MONITOR", async () => {
+      const { helper, commands } = loadNodeHelper();
+
+      helper.platform = "x11";
+      helper.socketNotificationReceived("DEACTIVATE_MONITOR");
+      await flush();
+
+      assert.deepStrictEqual(commands.length, 1);
+      assert.match(commands[0], /sh off$/);
+    });
+
+    it("ignores INIT_MONITOR without a payload", async () => {
+      const { helper, commands } = loadNodeHelper();
+
+      helper.socketNotificationReceived("INIT_MONITOR", undefined);
+      await flush();
+
+      assert.deepStrictEqual(commands, []);
+    });
+
+    it("does not shell out for an unrelated notification", async () => {
+      const { helper, commands } = loadNodeHelper();
+
+      helper.platform = "x11";
+      helper.socketNotificationReceived("SOMETHING_ELSE");
+      await flush();
+
+      assert.deepStrictEqual(commands, []);
+    });
+
+    it("logs an error when the script fails", async () => {
+      const { helper, logs } = loadNodeHelper({
+        exec: () => {
+          throw new Error("boom");
+        },
+      });
+
+      helper.platform = "x11";
+      helper.socketNotificationReceived("ACTIVATE_MONITOR");
+      await flush();
+
+      assert.strictEqual(logs.error.length, 1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- `activateMonitor`/`deactivateMonitor` each spawned an extra `status` subprocess before running the `on`/`off` command.
- All `monitor-commands-*.sh` scripts are idempotent (turning an already-on/off display on/off again is a no-op), so the pre-check added a subprocess spawn per toggle for no behavioral benefit.
- Simplified both functions to just run the toggle command directly. Removed `isMonitorOn()`, which had no other callers.

## Test plan
- [ ] `npm run lint` passes (ran locally, clean)
- [ ] Manually verify monitor on/off toggling still works on at least one platform

---

**Update:** rebased onto `develop` after #97 and #99 merged. The shared mock now comes from `develop` and these tests live in their own file, so there are no merge conflicts left.