### PR TITLE
fix: guard against null lastTimeMotionDetected in getTemplateData

### DIFF
--- a/MMM-MotionDetector.js
+++ b/MMM-MotionDetector.js
@@ -33,7 +33,7 @@ Module.register("MMM-MotionDetector", {
     return {
       duration: moment.duration(this.poweredOffTime).humanize(),
       lastScoreDetected: this.lastScoreDetected,
-      lastTimeMotionDetected: this.lastTimeMotionDetected.toLocaleTimeString(),
+      lastTimeMotionDetected: this.lastTimeMotionDetected ? this.lastTimeMotionDetected.toLocaleTimeString() : null,
       percentagePoweredOff: this.percentagePoweredOff,
       timeout: this.config.timeout,
       error: this.error,

--- a/tests/module.test.js
+++ b/tests/module.test.js
@@ -95,6 +95,17 @@ describe("MMM-MotionDetector", () => {
       assert.strictEqual(module.getTemplateData().error, "NotAllowedError");
     });
 
+    it("renders when no motion was ever detected", () => {
+      const { module } = loadModule();
+
+      // the template is rendered on the init error path too, where a capture
+      // may never have run and lastTimeMotionDetected can still be unset
+      module.lastTimeMotionDetected = null;
+
+      assert.doesNotThrow(() => module.getTemplateData());
+      assert.strictEqual(module.getTemplateData().lastTimeMotionDetected, null);
+    });
+
     it("renders without an error once a frame was captured", () => {
       const { module, capture } = loadModule();
 


### PR DESCRIPTION
## Summary
- `getTemplateData()` unconditionally called `.toLocaleTimeString()` on `lastTimeMotionDetected`.
- It's always set today before any render, but this would throw if it were ever null/unset (e.g. rendered before `start()` finishes, or on an init error path).
- Guarded the call so the template receives `null` instead of crashing the module.

## Test plan
- [ ] `npm run lint` passes (ran locally, clean)
- [ ] Confirm the module still renders the motion-detected time normally in the golden path