### PR TITLE
Add unit tests for the motion detection state machine

### DIFF
--- a/.github/workflows/automated-tests.yaml
+++ b/.github/workflows/automated-tests.yaml
@@ -31,6 +31,10 @@ jobs:
         run: node --run test:spelling
       - name: Check linting
         run: node --run lint
+      - name: Check shell scripts
+        run: shellcheck monitor-commands-*.sh
+      - name: Run unit tests
+        run: node --run test:unit
       - name: Report status
         if: always()
         run: echo "🍏 This job's status is ${{ job.status }}."

--- a/package.json
+++ b/package.json
@@ -18,8 +18,9 @@
     "lint": "eslint && prettier . --check",
     "lint:fix": "eslint --fix && prettier . --write",
     "prepare": "[ -f node_modules/.bin/husky ] && husky || echo info for developers: husky is not installed.",
-    "test": "node --run lint && node --run test:spelling",
-    "test:spelling": "cspell ."
+    "test": "node --run lint && node --run test:spelling && node --run test:unit",
+    "test:spelling": "cspell .",
+    "test:unit": "node --test \"tests/**/*.test.js\""
   },
   "lint-staged": {
     "*": [

--- a/tests/module-mock.js
+++ b/tests/module-mock.js
@@ -1,0 +1,71 @@
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+const MODULE_SOURCE = fs.readFileSync(path.join(__dirname, "..", "MMM-MotionDetector.js"), "utf8");
+
+/**
+ * Load MMM-MotionDetector.js outside of a browser.
+ *
+ * The interesting logic lives inside the callbacks handed to DiffCamEngine.init(),
+ * so we stub the engine out and keep the options object it receives. That gives us
+ * a handle on captureCallback, which can then be driven frame by frame.
+ * @param config config overrides merged over the module defaults
+ * @returns {{module: object, capture: Function, initError: Function}}
+ */
+function loadModule(config = {}) {
+  let definition;
+  let engineOptions;
+
+  const sandbox = {
+    Module: {
+      register: (name, moduleDefinition) => {
+        definition = moduleDefinition;
+      },
+    },
+    Log: { error() {}, info() {} },
+    moment: { duration: () => ({ humanize: () => "a while" }) },
+    document: { createElement: () => ({ appendChild() {}, style: "" }) },
+    DiffCamEngine: {
+      init: (options) => {
+        engineOptions = options;
+      },
+      start() {},
+    },
+  };
+
+  vm.createContext(sandbox);
+  vm.runInContext(MODULE_SOURCE, sandbox);
+
+  const module = Object.assign(Object.create(definition), definition, {
+    config: { ...definition.defaults, ...config },
+    data: { position: "top_left" },
+    notifications: [],
+    sendNotification(notification, payload) {
+      // payloads are built inside the vm realm, structuredClone brings them back over
+      this.notifications.push(["notification", notification, structuredClone(payload)]);
+    },
+    sendSocketNotification(notification, payload) {
+      this.notifications.push(["socket", notification, structuredClone(payload)]);
+    },
+    updateDom() {},
+  });
+
+  module.start();
+
+  // start() emits INIT_MONITOR, tests care about what happens afterwards
+  module.notifications.length = 0;
+
+  return { module, capture: engineOptions.captureCallback, initError: engineOptions.initErrorCallback };
+}
+
+/**
+ * Pretend the last motion happened a given number of milliseconds ago.
+ * @param module module instance returned by loadModule
+ * @param milliseconds age of the last detected motion
+ */
+function setLastMotionAge(module, milliseconds) {
+  module.lastTimeMotionDetected = new Date(Date.now() - milliseconds);
+}
+
+module.exports = { loadModule, setLastMotionAge };

--- a/tests/module.test.js
+++ b/tests/module.test.js
@@ -1,0 +1,127 @@
+const assert = require("node:assert");
+const { describe, it } = require("node:test");
+const { loadModule, setLastMotionAge } = require("./module-mock");
+
+describe("MMM-MotionDetector", () => {
+  describe("motion detected", () => {
+    it("announces motion on both the socket and the module bus", () => {
+      const { module, capture } = loadModule();
+
+      capture({ score: 42, hasMotion: true });
+
+      assert.deepStrictEqual(module.notifications, [
+        ["socket", "MOTION_DETECTED", { score: 42 }],
+        ["notification", "MOTION_DETECTED", { score: 42 }],
+      ]);
+      assert.strictEqual(module.lastScoreDetected, 42);
+    });
+
+    it("does not activate the monitor when it is already on", () => {
+      const { module, capture } = loadModule();
+
+      capture({ score: 42, hasMotion: true });
+
+      assert.ok(!module.notifications.some(([, notification]) => notification === "ACTIVATE_MONITOR"));
+    });
+
+    it("reactivates the monitor and books the powered off time", () => {
+      const { module, capture } = loadModule({ timeout: 1000 });
+
+      setLastMotionAge(module, 5000);
+      capture({ score: 1, hasMotion: false });
+      assert.strictEqual(module.poweredOff, true);
+
+      module.notifications.length = 0;
+      module.lastTimePoweredOff = new Date(Date.now() - 3000);
+      capture({ score: 50, hasMotion: true });
+
+      assert.ok(module.notifications.some(([, notification]) => notification === "ACTIVATE_MONITOR"));
+      assert.strictEqual(module.poweredOff, false);
+      assert.ok(module.poweredOffTime >= 3000, `expected at least 3000ms, got ${module.poweredOffTime}`);
+    });
+  });
+
+  describe("no motion", () => {
+    it("keeps the monitor on before the timeout elapsed", () => {
+      const { module, capture } = loadModule({ timeout: 120000 });
+
+      setLastMotionAge(module, 1000);
+      capture({ score: 1, hasMotion: false });
+
+      assert.deepStrictEqual(module.notifications, []);
+      assert.strictEqual(module.poweredOff, false);
+    });
+
+    it("powers the monitor off once the timeout elapsed", () => {
+      const { module, capture } = loadModule({ timeout: 1000 });
+
+      setLastMotionAge(module, 5000);
+      capture({ score: 1, hasMotion: false });
+
+      assert.deepStrictEqual(module.notifications, [["socket", "DEACTIVATE_MONITOR", undefined]]);
+      assert.strictEqual(module.poweredOff, true);
+    });
+
+    it("does not repeat DEACTIVATE_MONITOR on every following frame", () => {
+      const { module, capture } = loadModule({ timeout: 1000 });
+
+      setLastMotionAge(module, 5000);
+      capture({ score: 1, hasMotion: false });
+      module.notifications.length = 0;
+      capture({ score: 1, hasMotion: false });
+      capture({ score: 1, hasMotion: false });
+
+      assert.deepStrictEqual(module.notifications, []);
+    });
+
+    it("never powers the monitor off for a negative timeout", () => {
+      const { module, capture } = loadModule({ timeout: -1 });
+
+      setLastMotionAge(module, 24 * 60 * 60 * 1000);
+      capture({ score: 1, hasMotion: false });
+
+      assert.deepStrictEqual(module.notifications, []);
+      assert.strictEqual(module.poweredOff, false);
+    });
+  });
+
+  describe("template data", () => {
+    it("surfaces an init error", () => {
+      const { module, initError } = loadModule();
+
+      initError("NotAllowedError");
+
+      assert.strictEqual(module.error, "NotAllowedError");
+      assert.strictEqual(module.getTemplateData().error, "NotAllowedError");
+    });
+
+    it("renders without an error once a frame was captured", () => {
+      const { module, capture } = loadModule();
+
+      capture({ score: 42, hasMotion: true });
+      const data = module.getTemplateData();
+
+      assert.strictEqual(data.lastScoreDetected, 42);
+      assert.strictEqual(data.error, null);
+      assert.strictEqual(typeof data.lastTimeMotionDetected, "string");
+    });
+  });
+
+  describe("socket notifications", () => {
+    it("forwards USER_PRESENCE to the module bus", () => {
+      const { module } = loadModule();
+
+      module.socketNotificationReceived("USER_PRESENCE", true);
+
+      assert.deepStrictEqual(module.notifications, [["notification", "USER_PRESENCE", true]]);
+    });
+
+    it("ignores unknown notifications", () => {
+      const { module } = loadModule();
+
+      module.socketNotificationReceived("SOMETHING_ELSE", true);
+
+      assert.deepStrictEqual(module.notifications, []);
+    });
+  });
+});


### PR DESCRIPTION
## Why

The module had no test coverage beyond lint and spell checking. The logic that actually matters — the timeout state machine that powers the monitor on and off — lives inside the callbacks passed to `DiffCamEngine.init()`, which made it unreachable without a browser and a real webcam.

## How

`tests/module-mock.js` loads `MMM-MotionDetector.js` in a `vm` context with stubs for `Module`, `Log`, `moment`, `document` and `DiffCamEngine`, and keeps the options object the engine receives. That exposes `captureCallback`, so tests can drive the module frame by frame with synthetic scores — no browser, no camera, no new dependencies (`node:test` and `node:vm` are built in).

## What is covered

11 tests in four groups:

- **motion detected** — notifications go out on both buses, the monitor is not reactivated when already on, and reactivation books the powered-off time
- **no motion** — monitor stays on before the timeout, powers off after it, `DEACTIVATE_MONITOR` fires *once* rather than on every following frame, and `timeout: -1` never powers off
- **template data** — init errors reach the template, normal renders do not
- **socket notifications** — `USER_PRESENCE` is forwarded, unknown notifications are ignored

## CI

`test:unit` is chained into `npm test` and added as a workflow step, along with `shellcheck` over the five `monitor-commands-*.sh` scripts.

## Notes for review

- The shellcheck step is the one piece I could not verify locally (shellcheck is not installed on my machine). I read all five scripts instead — expansions are quoted and nothing obvious stands out — and shellcheck ships preinstalled on `ubuntu-latest`. If it goes red, dropping those two lines is the fix.
- `structuredClone` on the notification payloads is load-bearing: objects built inside the `vm` realm have a different `Object` prototype and fail `deepStrictEqual`. Without it the assertions would have to be loosened to `deepEqual`, which would silently weaken them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)