### PR TITLE
docs: fix errors and inconsistencies in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,48 +16,27 @@ git clone https://github.com/rejas/MMM-MotionDetector.git
 Accessing your (web)cam requires to have the client run on localhost or a HTTPS host (due to new requirements in Chrome for getUserMedia).
 The default value in your MagicMirror config.js is already `localhost` so most users shouldn't be affected.
 
-Just in case you still have problems (like [here](https://github.com/rejas/MMM-MotionDetector/issues/6)) check your config
-and see if you can solve it by uncommenting the ip-address under
+Just in case you still have problems (like [here](https://github.com/rejas/MMM-MotionDetector/issues/6)), check your config
+and make sure the address is **not** set to `0.0.0.0`:
 
-```JavaScript
+```javascript
 let config = {
-    	address : '0.0.0.0',
-	...
+  address: "localhost", // 0.0.0.0 will stop the browser from granting camera access
+  ...
 ```
+
+Chromium and Electron only offer the camera permission on `localhost` and `127.0.0.1`, so serving the mirror on
+`0.0.0.0` leaves the permission greyed out. If another module forces you to use `0.0.0.0`, see
+[the reverse proxy workaround](#configuring-motiondetector-with-another-module-that-requires-magicmirror-address-to-be-0000) below.
 
 ### Raspberry Pi OS
 
-Due to some changes on chromium and raspiOS (see https://github.com/rejas/MMM-MotionDetector/issues/56) the [legacy raspiOS](https://www.raspberrypi.com/news/new-old-functionality-with-raspberry-pi-os-legacy/) is needed.
+Getting the camera to work on current Raspberry Pi OS releases is still unresolved, see
+[issue #56](https://github.com/rejas/MMM-MotionDetector/issues/56). The workaround that used to be documented here
+relied on the legacy camera stack, which no longer exists on Bookworm and later, so it has been removed rather than
+left as misleading advice.
 
-Any help getting this module run on the default raspiOS is greatly appreciated!
-
-Some people had success with enabling the legacy camera mode in the default raspiOS, but this is not a 100% confirmed:
-
-```shell
-sudo raspi-config
-```
-
-Then go to
-
-```shell
-3 Interface Options -> I1 Legacy Camera
-```
-
-and enable legacy camera support.
-
-### Tested devices
-
-So far I only used a [PlayStation3 Eye Webcam](https://en.wikipedia.org/wiki/PlayStation_Eye) for motion-detection at my MagicMirror.
-If you have successfully used this module with any other webcam, I'd be happy to hear about it.
-
-If you want to use the wired PI-camera follow these steps provided by [@rev138](https://github.com/rejas/MMM-MotionDetector/issues/8#issuecomment-483356950):
-
-    - Open /etc/modules-load.d/modules.conf
-    - Add bcm2835-v4l2 to the end of the file and save it.
-    - Reboot.
-    - Profit
-
-Another tutorial on how to enable the PI-camera in the browser can be found [in this blog post](https://reprage.com/post/pi-camera-module-in-the-browser).
+Any help getting this module running on current Raspberry Pi OS is greatly appreciated.
 
 ## Configuration
 
@@ -84,8 +63,8 @@ The following properties can be configured:
 | --------------------- | ---------------------------------------------------------------------------------------------------------------------- | ------------- |
 | `captureIntervalTime` | Time in ms between capturing images for detection                                                                      | `1000`        |
 | `deviceId`            | (optional) specify which camera to use in case multiple exist in the system.                                           |               |
-| `platform`            | On what platforms this runs. <br><br>**Possible values:** `cec` (untested), `labwc`,`mac-intel`, `mac-intel`, `x11`    | `x11`         |
-| `scoreThreshold`      | Threshold minimum for an image to be considered significant                                                            | `20`          |
+| `platform`            | On what platforms this runs. <br><br>**Possible values:** `cec` (untested), `labwc`, `mac-arm`, `mac-intel`, `x11`     | `x11`         |
+| `scoreThreshold`      | Threshold minimum for an image to be considered significant.<br><br>Set to 0 to treat any movement as motion           | `20`          |
 | `timeout`             | Time in ms after which monitor is turned off when no motion is detected<br><br>Set to -1 to never turn off the monitor | `120000`      |
 
 #### How to get the deviceId
@@ -94,6 +73,20 @@ You need to retrieve the deviceId from the browser / electron instance you are r
 
 - If you are running it in a browser, use this command in the web console `navigator.mediaDevices.enumerateDevices()` to get all devices.
 - In the standard MM Electron, add 'export ELECTRON_ENABLE_LOGGING=true' to the mm.sh. Then cat the pm2 error logs and look for the DeviceID.
+
+### Tested devices
+
+So far I only used a [PlayStation3 Eye Webcam](https://en.wikipedia.org/wiki/PlayStation_Eye) for motion-detection at my MagicMirror.
+If you have successfully used this module with any other webcam, I'd be happy to hear about it.
+
+If you want to use the wired PI-camera follow these steps provided by [@rev138](https://github.com/rejas/MMM-MotionDetector/issues/8#issuecomment-483356950):
+
+- Open `/etc/modules-load.d/modules.conf`
+- Add `bcm2835-v4l2` to the end of the file and save it.
+- Reboot.
+- Profit
+
+Another tutorial on how to enable the PI-camera in the browser can be found [in this blog post](https://reprage.com/post/pi-camera-module-in-the-browser).
 
 ### Configuring MotionDetector with another module that requires MagicMirror address to be 0.0.0.0
 
@@ -105,38 +98,41 @@ Then you need to create 2 files:
 
 routes.json
 
-```JavaScript
+```json
 {
   "routes": [
     {
-      "route": "/mirror", // any path you like
-      "address": "http://localhost:8080" // address of MagicMirror
+      "route": "/mirror",
+      "address": "http://localhost:8080"
     }
   ]
 }
 ```
 
+The `route` is any path you like, the `address` is the one of your MagicMirror.
+
 proxyserver.js
 
-```JavaScript
+```javascript
 // Dependencies
-const express = require('express');
-const proxy = require('http-proxy-middleware');
+const express = require("express");
+const { createProxyMiddleware } = require("http-proxy-middleware");
 
 // Config
-const { routes } = require('./routes.json');
+const { routes } = require("./routes.json");
 
 const app = express();
 
-for (route of routes) {
-    app.use(route.route,
-        proxy({
-            target: route.address,
-            pathRewrite: (path, req) => {
-                return path.split('/').slice(2).join('/'); // Could use replace, but take care of the leading '/'
-            }
-        })
-    );
+for (const route of routes) {
+  app.use(
+    route.route,
+    createProxyMiddleware({
+      target: route.address,
+      pathRewrite: (path) => {
+        return path.split("/").slice(2).join("/"); // Could use replace, but take care of the leading '/'
+      }
+    })
+  );
 }
 
 // Start server and listen on port 8081
@@ -149,12 +145,16 @@ You can now call http://ipaddress:8081/mirror/modulename and it will be forwarde
 
 As you are bypassing browser security with this workaround you may want to add some credentials and/or ip-ranges which can access your proxyserver.
 
-## Notifications send
+## Notifications sent
 
-| Notification         | Payload       | Description                                                             |
-| -------------------- | ------------- | ----------------------------------------------------------------------- |
-| `MOTION_DETECTED`    | score         | score calculated by the diff-cam-engine, 0 or greater                   |
-| `DEACTIVATE_MONITOR` | percentageOff | percentage of time the monitor was deactivated since the module started |
+These are broadcast to the other modules on your mirror:
+
+| Notification      | Payload            | Description                                                                 |
+| ----------------- | ------------------ | --------------------------------------------------------------------------- |
+| `MOTION_DETECTED` | `{ score: <int> }` | score calculated by the diff-cam-engine for the current frame, 0 or greater |
+
+`ACTIVATE_MONITOR` and `DEACTIVATE_MONITOR` are also sent, but only over the socket to this module's own node helper,
+which switches the monitor on and off. They carry no payload and cannot be observed by other modules.
 
 ## Acknowledgements
 


### PR DESCRIPTION
Builds on the two uncommitted README changes that were sitting in the working tree (deleting the Raspberry Pi OS section, moving *Tested devices*), keeping the intent of both but reworking them — see the last section.

## Documented behaviour that did not match the code

**`platform` listed `mac-intel` twice and never mentioned `mac-arm`**, even though `VALID_PLATFORMS` accepts it and `monitor-commands-mac-arm.sh` exists. Apple Silicon users had no way to know their platform was supported.

**The notifications table was substantially wrong:**

- `DEACTIVATE_MONITOR` was listed as if other modules could observe it. It is only ever sent via `sendSocketNotification` to this module's own node helper — a module listening for it would never hear anything.
- Its documented `percentageOff` payload **does not exist anywhere in the codebase**. The nearest real thing is `percentagePoweredOff`, which is template-only and never sent. The string `percentageOff` appeared solely in the README.
- `MOTION_DETECTED` sends `{ score: … }`, not a bare number.

**`scoreThreshold: 0` is now honoured** after #103, so that is documented.

## A section that contradicted another section

Requirements suggested fixing camera problems by setting `address: '0.0.0.0'`. But the reverse-proxy section further down exists *precisely because* `0.0.0.0` stops the browser granting camera access — which is also what issue #56 reports. Reworded to say the opposite, and cross-linked the two.

## Broken example code

The proxy example could not run as written:

- `http-proxy-middleware` has exported `createProxyMiddleware` rather than a callable default since v1 (2020), so `proxy({...})` throws
- `for (route of routes)` was missing its declaration — a `ReferenceError` under strict mode

## The two working-tree changes, reworked

**Raspberry Pi OS** — restored, but short. Deleting it was the right instinct: the workaround relied on the legacy camera stack, which no longer exists on Bookworm, so it was actively misleading advice. But [#56](https://github.com/rejas/MMM-MotionDetector/issues/56) is still open and unresolved since Jan 2023, so the limitation is worth naming rather than dropping silently.

**Tested devices** — kept in Configuration as intended, but moved *below* `#### How to get the deviceId`. As placed, it sat between `### Configuration options` and that `####` subsection, which re-parented the deviceId docs under *Tested devices* instead of *Configuration options*.

## Also

Grammar (*Notifications send* → *sent*), the PI-camera steps rendered as an indented code block rather than the list they were meant to be, and fence languages were inconsistent (` ```JavaScript ` vs ` ```javascript `, plus JSON fenced as JavaScript).

Verified: lint, prettier, cspell (26 files, 0 issues) and the 55 unit tests all pass. The new intra-page anchor was checked against the heading it targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)