### PR TITLE
chore: remove the unreachable USER_PRESENCE handler

### DIFF
--- a/MMM-MotionDetector.js
+++ b/MMM-MotionDetector.js
@@ -40,13 +40,6 @@ Module.register("MMM-MotionDetector", {
     };
   },
 
-  // Override socket notification handler.
-  socketNotificationReceived: function (notification, payload) {
-    if (notification === "USER_PRESENCE") {
-      this.sendNotification(notification, payload);
-    }
-  },
-
   start: function () {
     Log.info("starting up for platform " + this.config.platform + ".");
 

--- a/tests/module.test.js
+++ b/tests/module.test.js
@@ -124,22 +124,4 @@ describe("MMM-MotionDetector", () => {
       assert.strictEqual(typeof data.lastTimeMotionDetected, "string");
     });
   });
-
-  describe("socket notifications", () => {
-    it("forwards USER_PRESENCE to the module bus", () => {
-      const { module } = loadModule();
-
-      module.socketNotificationReceived("USER_PRESENCE", true);
-
-      assert.deepStrictEqual(module.notifications, [["notification", "USER_PRESENCE", true]]);
-    });
-
-    it("ignores unknown notifications", () => {
-      const { module } = loadModule();
-
-      module.socketNotificationReceived("SOMETHING_ELSE", true);
-
-      assert.deepStrictEqual(module.notifications, []);
-    });
-  });
 });


### PR DESCRIPTION
## The finding

`MMM-MotionDetector.js` forwarded `USER_PRESENCE` from its node helper to the module bus:

```js
socketNotificationReceived: function (notification, payload) {
  if (notification === "USER_PRESENCE") {
    this.sendNotification(notification, payload);
  }
},
```

The helper has never sent it.

`git log -S "USER_PRESENCE" --all` finds the string in exactly **two** commits across the entire history:

- `d244dad`, the initial import on 2016-08-11, which carried it over from the upstream [alexyak/motiondetector](https://github.com/alexyak/motiondetector) project — the node helper in that same commit had no `sendSocketNotification` at all, only a receiver
- `af4c478`, the test suite added last week

There has never been a sender, in any file, at any point. Since `socketNotificationReceived` only ever hears from a module's *own* node helper — and this helper sends nothing back to the module even today — the branch has been unreachable for the entire ten-year life of the repository.

Same shape as the dead socket `MOTION_DETECTED` removed in #96, except that one at least had a live sender.

## The change

The handler existed solely for this one notification, so the whole method is removed rather than left as an empty shell.

Both tests covering it are removed too. They passed, but pinned behaviour no user could trigger — keeping them would have implied the path worked. This is why a green test is not by itself evidence a feature is reachable.

The node helper keeps its own `socketNotificationReceived`, which handles the live module → helper direction (`INIT_MONITOR`, `ACTIVATE_MONITOR`, `DEACTIVATE_MONITOR`) and is unaffected.

## Verification

- `grep` confirms no `USER_PRESENCE` reference remains anywhere in the repo
- 53 tests pass, exactly the previous 55 minus the two removed
- lint, prettier and cspell clean
- The README never documented `USER_PRESENCE`, so no docs change is needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)