### PR TITLE
feat: add controlDisplay and additionalNotification options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [develop](https://github.com/rejas/MMM-MotionDetector/compare/v1.8.1...develop) - unreleased
 
+### Added
+
+- `controlDisplay` option (default `true`), set it to `false` to detect motion and send notifications without switching the monitor on or off (#113)
+- `additionalNotification` option, broadcasts a user-named notification with the `{ score }` payload when someone arrives, i.e. motion returns after `timeout` of quiet (#113)
+
 ## [1.8.1](https://github.com/rejas/MMM-MotionDetector/compare/v1.8.0...v1.8.1) - 2026-09-01
 
 ### Changed

--- a/MMM-MotionDetector.js
+++ b/MMM-MotionDetector.js
@@ -13,6 +13,7 @@ Module.register("MMM-MotionDetector", {
   lastScoreDetected: null,
   lastTimeMotionDetected: null,
   lastTimePoweredOff: null,
+  idle: false, // true once motion has been absent longer than timeout, drives the arrival edge
   percentagePoweredOff: 0,
   poweredOff: false,
   poweredOffTime: 0,
@@ -92,7 +93,9 @@ Module.register("MMM-MotionDetector", {
         if (hasMotion) {
           Log.info(`Motion detected, score: ${score}`);
           this.sendNotification("MOTION_DETECTED", { score: score });
-          if (this.config.additionalNotification) {
+          // only on the arrival edge: motion returning after a quiet stretch,
+          // not on every frame someone stays in view
+          if (this.idle && this.config.additionalNotification) {
             this.sendNotification(this.config.additionalNotification, { score: score });
           }
           if (this.config.controlDisplay && this.poweredOff) {
@@ -101,13 +104,20 @@ Module.register("MMM-MotionDetector", {
             Log.info(`Percentage of uptime powered off:  ${this.percentagePoweredOff}`);
             this.sendSocketNotification("ACTIVATE_MONITOR");
           }
+          this.idle = false;
           this.lastTimeMotionDetected = currentDate;
         } else {
           const time = currentDate.getTime() - this.lastTimeMotionDetected.getTime();
-          if (this.config.controlDisplay && this.config.timeout >= 0 && time > this.config.timeout && !this.poweredOff) {
-            this.sendSocketNotification("DEACTIVATE_MONITOR");
-            this.lastTimePoweredOff = currentDate;
-            this.poweredOff = true;
+          if (this.config.timeout >= 0 && time > this.config.timeout) {
+            // the quiet threshold is display-independent so the arrival edge
+            // still works when controlDisplay is off, but powering the monitor
+            // down stays gated on controlDisplay
+            this.idle = true;
+            if (this.config.controlDisplay && !this.poweredOff) {
+              this.sendSocketNotification("DEACTIVATE_MONITOR");
+              this.lastTimePoweredOff = currentDate;
+              this.poweredOff = true;
+            }
           }
         }
         this.lastScoreDetected = score;

--- a/MMM-MotionDetector.js
+++ b/MMM-MotionDetector.js
@@ -6,6 +6,8 @@ Module.register("MMM-MotionDetector", {
     scoreThreshold: 20,
     timeout: 120000, // 2 minutes,
     deviceId: null,
+    controlDisplay: true, // switch the monitor on and off, set false to only detect motion
+    additionalNotification: null, // extra notification broadcast to other modules on motion
   },
 
   lastScoreDetected: null,
@@ -49,7 +51,9 @@ Module.register("MMM-MotionDetector", {
     this.lastTimePoweredOff = new Date();
     this.timeStarted = new Date().getTime();
 
-    this.sendSocketNotification("INIT_MONITOR", this.config.platform);
+    if (this.config.controlDisplay) {
+      this.sendSocketNotification("INIT_MONITOR", this.config.platform);
+    }
 
     const canvas = document.createElement("canvas");
     const video = document.createElement("video");
@@ -88,7 +92,10 @@ Module.register("MMM-MotionDetector", {
         if (hasMotion) {
           Log.info(`Motion detected, score: ${score}`);
           this.sendNotification("MOTION_DETECTED", { score: score });
-          if (this.poweredOff) {
+          if (this.config.additionalNotification) {
+            this.sendNotification(this.config.additionalNotification, { score: score });
+          }
+          if (this.config.controlDisplay && this.poweredOff) {
             this.poweredOffTime = poweredOffSoFar;
             this.poweredOff = false;
             Log.info(`Percentage of uptime powered off:  ${this.percentagePoweredOff}`);
@@ -97,7 +104,7 @@ Module.register("MMM-MotionDetector", {
           this.lastTimeMotionDetected = currentDate;
         } else {
           const time = currentDate.getTime() - this.lastTimeMotionDetected.getTime();
-          if (this.config.timeout >= 0 && time > this.config.timeout && !this.poweredOff) {
+          if (this.config.controlDisplay && this.config.timeout >= 0 && time > this.config.timeout && !this.poweredOff) {
             this.sendSocketNotification("DEACTIVATE_MONITOR");
             this.lastTimePoweredOff = currentDate;
             this.poweredOff = true;

--- a/README.md
+++ b/README.md
@@ -59,15 +59,15 @@ modules: [
 
 The following properties can be configured:
 
-| Option                   | Description                                                                                                                                                              | Default value |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------- |
-| `additionalNotification` | An extra notification broadcast to all modules whenever motion is detected, with the same `{ score }` payload as `MOTION_DETECTED`. Set to a notification name to enable | `null`        |
-| `captureIntervalTime`    | Time in ms between capturing images for detection                                                                                                                        | `1000`        |
-| `controlDisplay`         | Whether this module switches the monitor on and off. Set to `false` to detect motion and send notifications without touching the display                                 | `true`        |
-| `deviceId`               | (optional) specify which camera to use in case multiple exist in the system.                                                                                             |               |
-| `platform`               | On what platforms this runs. <br><br>**Possible values:** `cec` (untested), `labwc`, `mac-arm`, `mac-intel`, `x11`                                                       | `x11`         |
-| `scoreThreshold`         | Threshold minimum for an image to be considered significant.<br><br>Set to 0 to treat any movement as motion                                                             | `20`          |
-| `timeout`                | Time in ms after which monitor is turned off when no motion is detected<br><br>Set to -1 to never turn off the monitor                                                   | `120000`      |
+| Option                   | Description                                                                                                                                                                                                                                                                | Default value |
+| ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `additionalNotification` | An extra notification broadcast to all modules when someone arrives, i.e. motion returns after `timeout` of quiet, with a `{ score }` payload. Fires once per arrival, not every frame. Set to a notification name to enable. Needs `timeout >= 0` to have an arrival edge | `null`        |
+| `captureIntervalTime`    | Time in ms between capturing images for detection                                                                                                                                                                                                                          | `1000`        |
+| `controlDisplay`         | Whether this module switches the monitor on and off. Set to `false` to detect motion and send notifications without touching the display                                                                                                                                   | `true`        |
+| `deviceId`               | (optional) specify which camera to use in case multiple exist in the system.                                                                                                                                                                                               |               |
+| `platform`               | On what platforms this runs. <br><br>**Possible values:** `cec` (untested), `labwc`, `mac-arm`, `mac-intel`, `x11`                                                                                                                                                         | `x11`         |
+| `scoreThreshold`         | Threshold minimum for an image to be considered significant.<br><br>Set to 0 to treat any movement as motion                                                                                                                                                               | `20`          |
+| `timeout`                | Time in ms after which monitor is turned off when no motion is detected<br><br>Set to -1 to never turn off the monitor                                                                                                                                                     | `120000`      |
 
 #### How to get the deviceId
 
@@ -151,10 +151,10 @@ As you are bypassing browser security with this workaround you may want to add s
 
 These are broadcast to the other modules on your mirror:
 
-| Notification               | Payload            | Description                                                                                                                |
-| -------------------------- | ------------------ | -------------------------------------------------------------------------------------------------------------------------- |
-| `MOTION_DETECTED`          | `{ score: <int> }` | number of pixels the diff-cam-engine saw change in the current frame, always 1 or greater                                  |
-| _`additionalNotification`_ | `{ score: <int> }` | only if configured, sent on the same frames as `MOTION_DETECTED` with the notification name you chose (e.g. `TAKE_SELFIE`) |
+| Notification               | Payload            | Description                                                                                                                                  |
+| -------------------------- | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `MOTION_DETECTED`          | `{ score: <int> }` | number of pixels the diff-cam-engine saw change in the current frame, always 1 or greater                                                    |
+| _`additionalNotification`_ | `{ score: <int> }` | only if configured, sent once when someone arrives (motion after a quiet stretch) under the notification name you chose (e.g. `TAKE_SELFIE`) |
 
 `ACTIVATE_MONITOR` and `DEACTIVATE_MONITOR` are also sent, but only over the socket to this module's own node helper,
 which switches the monitor on and off. They carry no payload and cannot be observed by other modules.

--- a/README.md
+++ b/README.md
@@ -59,13 +59,15 @@ modules: [
 
 The following properties can be configured:
 
-| Option                | Description                                                                                                            | Default value |
-| --------------------- | ---------------------------------------------------------------------------------------------------------------------- | ------------- |
-| `captureIntervalTime` | Time in ms between capturing images for detection                                                                      | `1000`        |
-| `deviceId`            | (optional) specify which camera to use in case multiple exist in the system.                                           |               |
-| `platform`            | On what platforms this runs. <br><br>**Possible values:** `cec` (untested), `labwc`, `mac-arm`, `mac-intel`, `x11`     | `x11`         |
-| `scoreThreshold`      | Threshold minimum for an image to be considered significant.<br><br>Set to 0 to treat any movement as motion           | `20`          |
-| `timeout`             | Time in ms after which monitor is turned off when no motion is detected<br><br>Set to -1 to never turn off the monitor | `120000`      |
+| Option                   | Description                                                                                                                                                              | Default value |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------- |
+| `additionalNotification` | An extra notification broadcast to all modules whenever motion is detected, with the same `{ score }` payload as `MOTION_DETECTED`. Set to a notification name to enable | `null`        |
+| `captureIntervalTime`    | Time in ms between capturing images for detection                                                                                                                        | `1000`        |
+| `controlDisplay`         | Whether this module switches the monitor on and off. Set to `false` to detect motion and send notifications without touching the display                                 | `true`        |
+| `deviceId`               | (optional) specify which camera to use in case multiple exist in the system.                                                                                             |               |
+| `platform`               | On what platforms this runs. <br><br>**Possible values:** `cec` (untested), `labwc`, `mac-arm`, `mac-intel`, `x11`                                                       | `x11`         |
+| `scoreThreshold`         | Threshold minimum for an image to be considered significant.<br><br>Set to 0 to treat any movement as motion                                                             | `20`          |
+| `timeout`                | Time in ms after which monitor is turned off when no motion is detected<br><br>Set to -1 to never turn off the monitor                                                   | `120000`      |
 
 #### How to get the deviceId
 
@@ -149,9 +151,10 @@ As you are bypassing browser security with this workaround you may want to add s
 
 These are broadcast to the other modules on your mirror:
 
-| Notification      | Payload            | Description                                                                               |
-| ----------------- | ------------------ | ----------------------------------------------------------------------------------------- |
-| `MOTION_DETECTED` | `{ score: <int> }` | number of pixels the diff-cam-engine saw change in the current frame, always 1 or greater |
+| Notification               | Payload            | Description                                                                                                                |
+| -------------------------- | ------------------ | -------------------------------------------------------------------------------------------------------------------------- |
+| `MOTION_DETECTED`          | `{ score: <int> }` | number of pixels the diff-cam-engine saw change in the current frame, always 1 or greater                                  |
+| _`additionalNotification`_ | `{ score: <int> }` | only if configured, sent on the same frames as `MOTION_DETECTED` with the notification name you chose (e.g. `TAKE_SELFIE`) |
 
 `ACTIVATE_MONITOR` and `DEACTIVATE_MONITOR` are also sent, but only over the socket to this module's own node helper,
 which switches the monitor on and off. They carry no payload and cannot be observed by other modules.

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -7,6 +7,8 @@
     "canplay",
     "displaysleepnow",
     "fkms",
+    "initialise",
+    "initialises",
     "initialising",
     "ioreg",
     "labwc",

--- a/tests/module-mock.js
+++ b/tests/module-mock.js
@@ -53,10 +53,17 @@ function loadModule(config = {}) {
 
   module.start();
 
-  // start() emits INIT_MONITOR, tests care about what happens afterwards
+  // start() emits INIT_MONITOR; most tests care about what happens afterwards,
+  // so keep a snapshot for the few that check start() itself and then clear
+  const startNotifications = [...module.notifications];
   module.notifications.length = 0;
 
-  return { module, capture: engineOptions.captureCallback, initError: engineOptions.initErrorCallback };
+  return {
+    module,
+    startNotifications,
+    capture: engineOptions.captureCallback,
+    initError: engineOptions.initErrorCallback,
+  };
 }
 
 /**

--- a/tests/module.test.js
+++ b/tests/module.test.js
@@ -92,6 +92,79 @@ describe("MMM-MotionDetector", () => {
     });
   });
 
+  describe("additionalNotification", () => {
+    it("is not sent by default", () => {
+      const { module, capture } = loadModule();
+
+      capture({ score: 42, hasMotion: true });
+
+      assert.deepStrictEqual(module.notifications, [["notification", "MOTION_DETECTED", { score: 42 }]]);
+    });
+
+    it("is broadcast alongside MOTION_DETECTED when configured", () => {
+      const { module, capture } = loadModule({ additionalNotification: "TAKE_SELFIE" });
+
+      capture({ score: 42, hasMotion: true });
+
+      assert.deepStrictEqual(module.notifications, [
+        ["notification", "MOTION_DETECTED", { score: 42 }],
+        ["notification", "TAKE_SELFIE", { score: 42 }],
+      ]);
+    });
+
+    it("is not sent when there is no motion", () => {
+      const { module, capture } = loadModule({ additionalNotification: "TAKE_SELFIE" });
+
+      capture({ score: 1, hasMotion: false });
+
+      assert.ok(!module.notifications.some(([, notification]) => notification === "TAKE_SELFIE"));
+    });
+  });
+
+  describe("controlDisplay", () => {
+    it("initialises the monitor by default", () => {
+      const { startNotifications } = loadModule();
+
+      assert.ok(startNotifications.some(([, notification]) => notification === "INIT_MONITOR"));
+    });
+
+    it("does not initialise the monitor when disabled", () => {
+      const { startNotifications } = loadModule({ controlDisplay: false });
+
+      assert.ok(!startNotifications.some(([, notification]) => notification === "INIT_MONITOR"));
+    });
+
+    it("does not power the monitor off when disabled", () => {
+      const { module, capture } = loadModule({ controlDisplay: false, timeout: 1000 });
+
+      setLastMotionAge(module, 5000);
+      capture({ score: 1, hasMotion: false });
+
+      assert.ok(!module.notifications.some(([, notification]) => notification === "DEACTIVATE_MONITOR"));
+      assert.strictEqual(module.poweredOff, false);
+    });
+
+    it("does not activate the monitor on motion when disabled", () => {
+      const { module, capture } = loadModule({ controlDisplay: false, timeout: 1000 });
+
+      // even if some earlier state had marked it powered off, no ACTIVATE goes out
+      module.poweredOff = true;
+      capture({ score: 50, hasMotion: true });
+
+      assert.ok(!module.notifications.some(([, notification]) => notification === "ACTIVATE_MONITOR"));
+    });
+
+    it("still reports motion when display control is disabled", () => {
+      const { module, capture } = loadModule({ controlDisplay: false });
+
+      capture({ score: 42, hasMotion: true });
+
+      assert.ok(
+        module.notifications.some(([bus, notification]) => bus === "notification" && notification === "MOTION_DETECTED")
+      );
+    });
+  });
+
   describe("template data", () => {
     it("surfaces an init error", () => {
       const { module, initError } = loadModule();

--- a/tests/module.test.js
+++ b/tests/module.test.js
@@ -93,31 +93,100 @@ describe("MMM-MotionDetector", () => {
   });
 
   describe("additionalNotification", () => {
-    it("is not sent by default", () => {
-      const { module, capture } = loadModule();
+    const hasSelfie = (module) =>
+      module.notifications.some(([bus, notification]) => bus === "notification" && notification === "TAKE_SELFIE");
 
+    /** Drive the module into the idle state so the next motion is an arrival. */
+    const goIdle = (module, capture) => {
+      setLastMotionAge(module, 5000);
+      capture({ score: 1, hasMotion: false });
+      module.notifications.length = 0;
+    };
+
+    it("is not sent by default", () => {
+      const { module, capture } = loadModule({ timeout: 1000 });
+
+      goIdle(module, capture);
       capture({ score: 42, hasMotion: true });
 
-      assert.deepStrictEqual(module.notifications, [["notification", "MOTION_DETECTED", { score: 42 }]]);
+      assert.ok(!hasSelfie(module));
     });
 
-    it("is broadcast alongside MOTION_DETECTED when configured", () => {
+    it("fires on the arrival edge with the score payload", () => {
+      const { module, capture } = loadModule({ additionalNotification: "TAKE_SELFIE", timeout: 1000 });
+
+      goIdle(module, capture);
+      capture({ score: 42, hasMotion: true });
+
+      assert.ok(
+        module.notifications.some(
+          ([bus, notification, payload]) =>
+            bus === "notification" && notification === "TAKE_SELFIE" && payload.score === 42
+        )
+      );
+    });
+
+    it("does not fire on the first motion, since there was no quiet period", () => {
       const { module, capture } = loadModule({ additionalNotification: "TAKE_SELFIE" });
 
       capture({ score: 42, hasMotion: true });
 
-      assert.deepStrictEqual(module.notifications, [
-        ["notification", "MOTION_DETECTED", { score: 42 }],
-        ["notification", "TAKE_SELFIE", { score: 42 }],
-      ]);
+      assert.ok(!hasSelfie(module));
+    });
+
+    it("does not repeat while motion continues", () => {
+      const { module, capture } = loadModule({ additionalNotification: "TAKE_SELFIE", timeout: 1000 });
+
+      goIdle(module, capture);
+      capture({ score: 42, hasMotion: true }); // arrival, fires
+      module.notifications.length = 0;
+      capture({ score: 50, hasMotion: true }); // still present, must not fire again
+
+      assert.ok(!hasSelfie(module));
+    });
+
+    it("fires again on a second arrival after going quiet once more", () => {
+      const { module, capture } = loadModule({ additionalNotification: "TAKE_SELFIE", timeout: 1000 });
+
+      goIdle(module, capture);
+      capture({ score: 42, hasMotion: true });
+      goIdle(module, capture);
+      capture({ score: 42, hasMotion: true });
+
+      assert.ok(hasSelfie(module));
     });
 
     it("is not sent when there is no motion", () => {
-      const { module, capture } = loadModule({ additionalNotification: "TAKE_SELFIE" });
+      const { module, capture } = loadModule({ additionalNotification: "TAKE_SELFIE", timeout: 1000 });
 
+      setLastMotionAge(module, 5000);
       capture({ score: 1, hasMotion: false });
 
-      assert.ok(!module.notifications.some(([, notification]) => notification === "TAKE_SELFIE"));
+      assert.ok(!hasSelfie(module));
+    });
+
+    it("fires on arrival even when display control is off", () => {
+      const { module, capture } = loadModule({
+        additionalNotification: "TAKE_SELFIE",
+        controlDisplay: false,
+        timeout: 1000,
+      });
+
+      goIdle(module, capture);
+      capture({ score: 42, hasMotion: true });
+
+      assert.ok(hasSelfie(module));
+      assert.ok(!module.notifications.some(([, notification]) => notification === "ACTIVATE_MONITOR"));
+    });
+
+    it("never fires when the timeout is negative, there is no quiet threshold", () => {
+      const { module, capture } = loadModule({ additionalNotification: "TAKE_SELFIE", timeout: -1 });
+
+      setLastMotionAge(module, 24 * 60 * 60 * 1000);
+      capture({ score: 1, hasMotion: false });
+      capture({ score: 42, hasMotion: true });
+
+      assert.ok(!hasSelfie(module));
     });
   });
 


### PR DESCRIPTION
Salvages the two features from the stale draft #67 and reimplements them on current `develop`.

## Features

**`controlDisplay`** (default `true`) — do motion detection without touching the monitor. Setting it `false` gates **all three** monitor commands (`INIT_MONITOR`, `ACTIVATE_MONITOR`, `DEACTIVATE_MONITOR`), so `MOTION_DETECTED` and the arrival notification still flow but the display is left alone. With it off the module degrades into a pure motion sensor.

**`additionalNotification`** (default `null`) — broadcast a user-named notification (e.g. `TAKE_SELFIE`) when someone **arrives**: motion returning after `timeout` of quiet. Carries a `{ score }` payload. Fires **once per arrival**, not on every frame.

## On the firing cadence

The first version of this branch fired the extra notification on every motion frame, mirroring `MOTION_DETECTED`. That's wrong for the documented action use cases — it would trigger `TAKE_SELFIE` every capture interval (default 1s) for as long as someone stood in view. Changed to fire on the arrival edge instead, which is what the examples imply and what the original #67 did.

Implementation note: the arrival edge is tracked with a display-independent `idle` flag, not `poweredOff`. Reusing `poweredOff` would have set it true even when `controlDisplay: false`, making `percentagePoweredOff` report time the display was never actually off — the same misleading-metric class the release review flagged. Because the quiet threshold is `timeout`, `timeout: -1` leaves no arrival edge and the notification never fires (documented).

## Why this is a rebuild, not a rebase of #67

#67 is 34 commits behind and carries three real bugs — it dropped `scoreThreshold` from the engine init (so the configured threshold silently stopped applying), moved `MOTION_DETECTED` inside the powered-off branch (so it only fired on wake), and only guarded the deactivate under `controlDisplay` (so a mirror would switch on but never off). It also reintroduces the `USER_PRESENCE` handler and dead socket `MOTION_DETECTED` removed in #107 / #96. Kept the two ideas, none of the implementation.

## Tests

The suite goes to 82. Coverage: arrival edge fires once with the score payload; no repeat while motion continues; no fire on the first motion or with a negative timeout; arrival still fires when `controlDisplay` is off; and the `controlDisplay` gating of all three monitor commands. The distinguishing arrival-edge tests were verified to fail against the every-frame version.

The test mock also snapshots the notifications `start()` emits (`startNotifications`) so the `INIT_MONITOR` gating is testable.

## #67

Suggest closing #67 once this merges — superseded here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)