### PR TITLE
chore: rename the CI job from run-lint to lint-and-test

### DIFF
--- a/.github/workflows/automated-tests.yaml
+++ b/.github/workflows/automated-tests.yaml
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 jobs:
-  run-lint:
+  lint-and-test:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
The workflow already runs the full check set — cspell, eslint + prettier, shellcheck, and the unit suite — but the job was still called `run-lint`, from before the tests existed. That id is the name GitHub shows as the status check on every PR, so it read as if CI only linted.

Renamed the job to `lint-and-test` to match what it does. One line; no steps changed.

## Heads-up on the status check name

This changes the reported check from `run-lint` to `lint-and-test`. If `main` or `develop` has a **branch protection rule requiring the `run-lint` check by name**, that rule would need updating to `lint-and-test` or merges would block on a check that no longer reports. PRs have been merging clean all along without required-check gating, so I don't believe any such rule exists — but I can't read branch protection from here, so flagging it rather than assuming. Easy to check under Settings → Branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)