### PR TITLE
Release 1.8.1

### DIFF
--- a/.github/workflows/automated-tests.yaml
+++ b/.github/workflows/automated-tests.yaml
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 jobs:
-  run-lint:
+  lint-and-test:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,14 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [develop](https://github.com/rejas/MMM-MotionDetector/compare/v1.8.0...develop) - unreleased
+## [develop](https://github.com/rejas/MMM-MotionDetector/compare/v1.8.1...develop) - unreleased
+
+## [1.8.1](https://github.com/rejas/MMM-MotionDetector/compare/v1.8.0...v1.8.1) - 2026-09-01
+
+### Changed
+
+- The CI job `run-lint` was renamed to `lint-and-test` (#114)
+- Dev dependencies updated to their latest versions (#120, #125)
 
 ## [1.8.0](https://github.com/rejas/MMM-MotionDetector/compare/v1.7.0...v1.8.0) - 2026-07-21
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mmm-motiondetector",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mmm-motiondetector",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,14 +10,14 @@
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^10.0.1",
-        "@eslint/json": "^2.0.1",
+        "@eslint/json": "^2.1.0",
         "@eslint/markdown": "^8.0.3",
-        "cspell": "^10.0.1",
-        "eslint": "^10.8.0",
+        "cspell": "^10.2.0",
+        "eslint": "^10.9.1",
         "eslint-plugin-import-x": "^4.17.1",
-        "globals": "^17.9.0",
+        "globals": "^17.12.0",
         "husky": "^9.1.7",
-        "lint-staged": "^17.3.0",
+        "lint-staged": "^17.4.1",
         "prettier": "^3.9.6"
       },
       "engines": {
@@ -25,30 +25,30 @@
       }
     },
     "node_modules/@cspell/cspell-bundled-dicts": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-10.0.1.tgz",
-      "integrity": "sha512-WvkSDNX4Uyyj/ZgbPO6L38iFNMfK1EqsH1FteRiI2qLz6QZMXRFrIt12OqiWIplzZDDaVpBH9FCJOPJll0fjCQ==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-10.2.0.tgz",
+      "integrity": "sha512-pNdBzc3+njM1A8cp0t/az+FbwBoiIzKCJ15gHVdEtynGOH+GLKzpbNeRAXe3ci+BYUjQQXlQrCKalXaa+ZXVtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspell/dict-ada": "^4.1.1",
         "@cspell/dict-al": "^1.1.1",
         "@cspell/dict-aws": "^4.0.17",
-        "@cspell/dict-bash": "^4.2.2",
-        "@cspell/dict-companies": "^3.2.11",
-        "@cspell/dict-cpp": "^7.0.2",
+        "@cspell/dict-bash": "^4.2.3",
+        "@cspell/dict-companies": "^3.2.12",
+        "@cspell/dict-cpp": "^7.1.0",
         "@cspell/dict-cryptocurrencies": "^5.0.5",
         "@cspell/dict-csharp": "^4.0.8",
-        "@cspell/dict-css": "^4.1.1",
+        "@cspell/dict-css": "^4.1.2",
         "@cspell/dict-dart": "^2.3.2",
-        "@cspell/dict-data-science": "^2.0.13",
+        "@cspell/dict-data-science": "^2.0.16",
         "@cspell/dict-django": "^4.1.6",
         "@cspell/dict-docker": "^1.1.17",
         "@cspell/dict-dotnet": "^5.0.13",
         "@cspell/dict-elixir": "^4.0.8",
-        "@cspell/dict-en_us": "^4.4.33",
-        "@cspell/dict-en-common-misspellings": "^2.1.12",
-        "@cspell/dict-en-gb-mit": "^3.1.22",
+        "@cspell/dict-en_us": "^4.4.37",
+        "@cspell/dict-en-common-misspellings": "^2.2.0",
+        "@cspell/dict-en-gb-mit": "^3.1.26",
         "@cspell/dict-filetypes": "^3.0.18",
         "@cspell/dict-flutter": "^1.1.1",
         "@cspell/dict-fonts": "^4.0.6",
@@ -56,37 +56,37 @@
         "@cspell/dict-fullstack": "^3.2.9",
         "@cspell/dict-gaming-terms": "^1.1.2",
         "@cspell/dict-git": "^3.1.0",
-        "@cspell/dict-golang": "^6.0.26",
+        "@cspell/dict-golang": "^6.0.27",
         "@cspell/dict-google": "^1.0.9",
         "@cspell/dict-haskell": "^4.0.6",
-        "@cspell/dict-html": "^4.0.15",
+        "@cspell/dict-html": "^4.0.16",
         "@cspell/dict-html-symbol-entities": "^4.0.5",
         "@cspell/dict-java": "^5.0.12",
         "@cspell/dict-julia": "^1.1.1",
-        "@cspell/dict-k8s": "^1.0.12",
+        "@cspell/dict-k8s": "^1.0.13",
         "@cspell/dict-kotlin": "^1.1.1",
         "@cspell/dict-latex": "^5.1.0",
         "@cspell/dict-lorem-ipsum": "^4.0.5",
         "@cspell/dict-lua": "^4.0.8",
         "@cspell/dict-makefile": "^1.0.5",
-        "@cspell/dict-markdown": "^2.0.16",
-        "@cspell/dict-monkeyc": "^1.0.12",
+        "@cspell/dict-markdown": "^2.0.18",
+        "@cspell/dict-monkeyc": "^1.1.0",
         "@cspell/dict-node": "^5.0.9",
-        "@cspell/dict-npm": "^5.2.38",
+        "@cspell/dict-npm": "^5.2.47",
         "@cspell/dict-php": "^4.1.1",
         "@cspell/dict-powershell": "^5.0.15",
         "@cspell/dict-public-licenses": "^2.0.16",
-        "@cspell/dict-python": "^4.2.26",
+        "@cspell/dict-python": "^4.5.0",
         "@cspell/dict-r": "^2.1.1",
-        "@cspell/dict-ruby": "^5.1.1",
+        "@cspell/dict-ruby": "^5.1.2",
         "@cspell/dict-rust": "^4.1.2",
         "@cspell/dict-scala": "^5.0.9",
-        "@cspell/dict-shell": "^1.1.2",
-        "@cspell/dict-software-terms": "^5.2.2",
+        "@cspell/dict-shell": "^1.2.0",
+        "@cspell/dict-software-terms": "^5.4.2",
         "@cspell/dict-sql": "^2.2.1",
         "@cspell/dict-svelte": "^1.0.7",
         "@cspell/dict-swift": "^2.0.6",
-        "@cspell/dict-terraform": "^1.1.3",
+        "@cspell/dict-terraform": "^1.1.4",
         "@cspell/dict-typescript": "^3.2.3",
         "@cspell/dict-vue": "^3.0.5",
         "@cspell/dict-zig": "^1.0.0"
@@ -96,22 +96,22 @@
       }
     },
     "node_modules/@cspell/cspell-json-reporter": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-json-reporter/-/cspell-json-reporter-10.0.1.tgz",
-      "integrity": "sha512-/nes1RGILec3WCBcoMOd0byNTBtnJuPaVz/+ZzqYkLtY7x58VMcBG5kyP6hPyN8cIwjRADE/SR43gwdXuqk/FA==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-json-reporter/-/cspell-json-reporter-10.2.0.tgz",
+      "integrity": "sha512-2iKTU/UPkSV9O4EzWSFreqM4/RTLoYnvCA9dmh9hJnmarYu/eDJk1CIVu+HgMlOiyCI3cgVux+649vJ0T2dHrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-types": "10.0.1"
+        "@cspell/cspell-types": "10.2.0"
       },
       "engines": {
         "node": ">=22.18.0"
       }
     },
     "node_modules/@cspell/cspell-performance-monitor": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-performance-monitor/-/cspell-performance-monitor-10.0.1.tgz",
-      "integrity": "sha512-9tVcHXwRnbazUv4WSG0h3MqV4+LgmLNgSALAQUflPPW0EMxTf7C4Dmv9cgxJyCEQrdnVKCr58nPPaahhz9LJUg==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-performance-monitor/-/cspell-performance-monitor-10.2.0.tgz",
+      "integrity": "sha512-Wzh984VNI+nkNiVSC4yXbzdVhVnxtxcvtCmslVhk7wc0nmwN5r9M4TQ1k5tSOihVMJn4iV3+fy3TUjkrSsppFA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -119,9 +119,9 @@
       }
     },
     "node_modules/@cspell/cspell-pipe": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-10.0.1.tgz",
-      "integrity": "sha512-HPeXMD9AZ3V/qPkvQaPcak+C7cJ2z7JTHN8smd6J8L2aThLRky2cHc2OyeaHPSHB7WA47b4z2n5u5nawZhv5VQ==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-10.2.0.tgz",
+      "integrity": "sha512-BlA7k9kjgH7LxA3DZGRvOo2Cs9wArR0ux6gvmweoyD+zbOsZquTfrCwnU9IoctTy7HjuYrsE7mvCCN6xP11E7g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -129,9 +129,9 @@
       }
     },
     "node_modules/@cspell/cspell-resolver": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-resolver/-/cspell-resolver-10.0.1.tgz",
-      "integrity": "sha512-PIzkZHD1fGUQx1XteK2d1iQ0Mzq/maYcoB4jkvAiiR6WqP3MWYNKFdI9z+R5pOq5KgMfW+5Ig1q0oSR6h8irlA==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-resolver/-/cspell-resolver-10.2.0.tgz",
+      "integrity": "sha512-m94I4iTzWaklOr+eNxy/kgpcJYS9dMzeEsZKV6uprVCPNLNn63Ic+ChadNErwV2ii3tiNLAkn8VJy84oe2h1YA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -142,9 +142,9 @@
       }
     },
     "node_modules/@cspell/cspell-service-bus": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-10.0.1.tgz",
-      "integrity": "sha512-y6NcIGP2IdXaBL4PVH8vxsr7K27wzz3Ech87UtUtrDSXAiVEOvXgAIknEOUVp59rTlUE8Rn4IRURC6f/hgMyfw==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-10.2.0.tgz",
+      "integrity": "sha512-r061UxqmEwZK+XiW0dnbE6r7nKHNavQJ4PVw2zqzBVtcFj9YU9LCpOZx4mL49IlmCWxy7jf2jAD9w8nFPn1pWg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -152,9 +152,9 @@
       }
     },
     "node_modules/@cspell/cspell-types": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-10.0.1.tgz",
-      "integrity": "sha512-kLgLShnWADDVreKC63pBrWkcvxgZzFIfO34Jhx/SWfuOIA3cD8AXT+HjyuLfoGJ7mUb58hv2kUziKzEy4INb1w==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-10.2.0.tgz",
+      "integrity": "sha512-tkmOVCm2XzPUipa8eIu88ShRogjJ5RIen3y9kzBn51re5Nmjw4HDWRLbeBP1WTGFYR7bMi2h0ybnH0BuBCA29g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -162,13 +162,13 @@
       }
     },
     "node_modules/@cspell/cspell-worker": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-worker/-/cspell-worker-10.0.1.tgz",
-      "integrity": "sha512-L2bJerfuYOls2wEknm8FmynLtj/G7O4UqX9I/HznRggEW6i2yZIxagDetpVDNowpyavNHJ3SJtUFiyMiZc16Sw==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-worker/-/cspell-worker-10.2.0.tgz",
+      "integrity": "sha512-6yom68ucNQIUA56gEsXtoquM55AeQBKaMe/a35a91HIvB7AyhrTRTTeheuE/Gl2FUyszHecdewC6sbYELaAsvA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cspell-lib": "10.0.1"
+        "cspell-lib": "10.2.0"
       },
       "engines": {
         "node": ">=22.18.0"
@@ -213,9 +213,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-cpp": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-cpp/-/dict-cpp-7.0.2.tgz",
-      "integrity": "sha512-dfbeERiVNeqmo/npivdR6rDiBCqZi3QtjH2Z0HFcXwpdj6i97dX1xaKyK2GUsO/p4u1TOv63Dmj5Vm48haDpuA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-cpp/-/dict-cpp-7.1.0.tgz",
+      "integrity": "sha512-rcjycobioQUd9Jm/Y1n8U+sq6ytpZ0iV8AYIo+vyEFfutC5x7g6hL6Fh3bCdh6IporGHRqfEutGK/4sfopD2ZA==",
       "dev": true,
       "license": "MIT"
     },
@@ -283,23 +283,23 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-en_us": {
-      "version": "4.4.36",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.4.36.tgz",
-      "integrity": "sha512-2yOhI/+7d1DbfvMljGW4jw8pLqDEsVmnvUXBOCFXtLU2BWgQkrqOJDCNseYjEiEbTp0OtdrWEWWPFSP1TNugQw==",
+      "version": "4.4.37",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.4.37.tgz",
+      "integrity": "sha512-rMKyPrk2SKmDU+Bj0U0ixsv4Du93oijwovc8XlUin0zwKOJZb0/PFG5Df4P8CrM2CrLeovpaFvhoI98DigxBLw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@cspell/dict-en-common-misspellings": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-en-common-misspellings/-/dict-en-common-misspellings-2.1.13.tgz",
-      "integrity": "sha512-00rpydUxKNWY2xxrSx+h46aNWLvbkJdd57SsnEFt24fbs1fROhXZ6XSQu+gQz/zNuiCvFi4Ro3ej9DLbEdWQmQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-en-common-misspellings/-/dict-en-common-misspellings-2.2.0.tgz",
+      "integrity": "sha512-5PmCHv+AhY0LVNo3bE1FdRKMmw1esKj83GPwLymnVPYNtlI2Jf6y27EjC0azg4zny5keWmku0GQiMf55Fi+qeA==",
       "dev": true,
       "license": "CC BY-SA 4.0"
     },
     "node_modules/@cspell/dict-en-gb-mit": {
-      "version": "3.1.25",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-en-gb-mit/-/dict-en-gb-mit-3.1.25.tgz",
-      "integrity": "sha512-zGODptk24CMrXi49ieG2SUm94CKxEsVF0dYNF+1ZYH0MSsQDZ/PKDlrrbvtBqSupKdPSj0Z9sjOmMNfHHW9ZSg==",
+      "version": "3.1.26",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-en-gb-mit/-/dict-en-gb-mit-3.1.26.tgz",
+      "integrity": "sha512-F9Y/45+1oIPzfL/pyWLp4kzX+vddHPAYpIpIF+45bdc65AebeEiQHKzSmKgGGTd3qbQc3fATw2kAFdLryiQpjQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -353,9 +353,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-golang": {
-      "version": "6.0.26",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-golang/-/dict-golang-6.0.26.tgz",
-      "integrity": "sha512-YKA7Xm5KeOd14v5SQ4ll6afe9VSy3a2DWM7L9uBq4u3lXToRBQ1W5PRa+/Q9udd+DTURyVVnQ+7b9cnOlNxaRg==",
+      "version": "6.0.27",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-golang/-/dict-golang-6.0.27.tgz",
+      "integrity": "sha512-rRDb2JL8EefaezHGTEclKXCs4eMOS0q/datk94Lm7KQOhlGlzS9FDVZiR1/guh0o+iJCmejQuf5NR2FQeQSWsg==",
       "dev": true,
       "license": "MIT"
     },
@@ -374,9 +374,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-html": {
-      "version": "4.0.15",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-html/-/dict-html-4.0.15.tgz",
-      "integrity": "sha512-GJYnYKoD9fmo2OI0aySEGZOjThnx3upSUvV7mmqUu8oG+mGgzqm82P/f7OqsuvTaInZZwZbo+PwJQd/yHcyFIw==",
+      "version": "4.0.16",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-html/-/dict-html-4.0.16.tgz",
+      "integrity": "sha512-9B6/Cpb5YVcYgsEAlKudun1yd4ONllYS/ZibKLYea2apPR+l2vQdARnPrP9kTqa7NUNfRKl7m9Fb6k9rjimnow==",
       "dev": true,
       "license": "MIT"
     },
@@ -444,22 +444,22 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-markdown": {
-      "version": "2.0.17",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-markdown/-/dict-markdown-2.0.17.tgz",
-      "integrity": "sha512-H8bAxih6U8NOnSPL7R8My+tqjaB4tmnJTjERuz4zYqmf+cH+5xshX3UVgKlwWFcyjsYfv/zEDuRdMctQv1q6HQ==",
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-markdown/-/dict-markdown-2.0.18.tgz",
+      "integrity": "sha512-KLRSwVrwKDz4n7bl2XQjzvaBZbGgx5QKkP5Ok1b24xaO3TpXsLhAbAn1mItvFlI2tF6Rkt83iYjQcYppywuf5Q==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@cspell/dict-css": "^4.1.2",
-        "@cspell/dict-html": "^4.0.15",
+        "@cspell/dict-html": "^4.0.16",
         "@cspell/dict-html-symbol-entities": "^4.0.5",
         "@cspell/dict-typescript": "^3.2.3"
       }
     },
     "node_modules/@cspell/dict-monkeyc": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-monkeyc/-/dict-monkeyc-1.0.12.tgz",
-      "integrity": "sha512-MN7Vs11TdP5mbdNFQP5x2Ac8zOBm97ARg6zM5Sb53YQt/eMvXOMvrep7+/+8NJXs0jkp70bBzjqU4APcqBFNAw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-monkeyc/-/dict-monkeyc-1.1.0.tgz",
+      "integrity": "sha512-mc/hgvSy/emOIYtc8kuVEaLUlnaERunfAubfJ5plUXq6s0A69bcukJzUzSt9C0UTCwS28641ILRPv80m3L9QbA==",
       "dev": true,
       "license": "MIT"
     },
@@ -471,9 +471,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-npm": {
-      "version": "5.2.43",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.2.43.tgz",
-      "integrity": "sha512-H2gYwtu59dNO9662Uq0usfuhyNd7lZJE1C61a/UXcpRyWWSrTo2Bz+vwGYp1bXZ1LmjXadqvwJ8ArFlGdiadNQ==",
+      "version": "5.2.48",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.2.48.tgz",
+      "integrity": "sha512-R5dDnXTxZFOdb/4XSugCjsb3gXTHcEURGFAVOThg5QVu2YRI+yYj5vGgj9gSNffbgoQsNnaukPoB5v1tjF+tRA==",
       "dev": true,
       "license": "MIT"
     },
@@ -499,9 +499,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-python": {
-      "version": "4.2.29",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-python/-/dict-python-4.2.29.tgz",
-      "integrity": "sha512-OnEt1a35iuQzc2Ize1qU/43ZyF10urRKAm+mlTz++vnAgDLBHpKfWakpSK50nyL5/1WvyQ8BaMjb52MBLEpTeA==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-python/-/dict-python-4.5.0.tgz",
+      "integrity": "sha512-O1lSuFXoX8p+4hvJMbqvg3blbn0Zx8LHqdPQSNaOxFZGf7hmq6pc8sfta+98E7Q/WtDooAnU3XpBxBXcn0r94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -516,9 +516,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-ruby": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-ruby/-/dict-ruby-5.1.1.tgz",
-      "integrity": "sha512-LHrp84oEV6q1ZxPPyj4z+FdKyq1XAKYPtmGptrd+uwHbrF/Ns5+fy6gtSi7pS+uc0zk3JdO9w/tPK+8N1/7WUA==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-ruby/-/dict-ruby-5.1.2.tgz",
+      "integrity": "sha512-f6Slf11N91ittf71AWlfVVG9GZPezVRBfcMPCTNTWhUsY/VEspkBRZYDhPXjV4df3jqHy5YJs8nlsFcFVF/bMA==",
       "dev": true,
       "license": "MIT"
     },
@@ -544,9 +544,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-software-terms": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-5.2.4.tgz",
-      "integrity": "sha512-z6y/TGH3QNf5wB4pVvN/P3GfFEW/Whf6QAekNsIn06VKl95dnamfpkPWqV8rEtCixQFaKalb5+y9hRQXH3XQ1g==",
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-5.4.2.tgz",
+      "integrity": "sha512-C2tS1JjxqHef9TpPRm08a6n+PJCrKrD6FsmPEyXb2J6TFef4FFnKRcGOf3pFnd+a6/oyQgXZWeKiECH6lBFjQA==",
       "dev": true,
       "license": "MIT"
     },
@@ -600,13 +600,13 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dynamic-import": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-10.0.1.tgz",
-      "integrity": "sha512-mP1gdq00aIcH8HxNMqnH11X6BKxLcneDtFgl/ecjIKnaGKwi44m8AndP5Kr4ODaYdl8UUw9O3dJh7KaQXnLHZQ==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-10.2.0.tgz",
+      "integrity": "sha512-FpmedZcu9qcN14/awVPISEBi3A1nPR2zyLslvSRhp6GPJt0YsRVBR5BDKxbLNIGqvM2xg3ZLjo2eGTjThiyHxA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/url": "10.0.1",
+        "@cspell/url": "10.2.0",
         "import-meta-resolve": "^4.2.0"
       },
       "engines": {
@@ -614,9 +614,9 @@
       }
     },
     "node_modules/@cspell/filetypes": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@cspell/filetypes/-/filetypes-10.0.1.tgz",
-      "integrity": "sha512-Z5S35giU5IW49fBBq6BksUbE8PC4IYPfaKuwl5Nl9jkf/OkAKiBmCowKX45NzRUQInwK/GSqqIUifrNeI6LdLw==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@cspell/filetypes/-/filetypes-10.2.0.tgz",
+      "integrity": "sha512-1I1wnjGqJkQqoHWZ8I28HuMPLG7yzJOh//rGGHBZE6Ly2loJWhk4+/Fa4wEoZ71Ss1HQii9d7smB0B/w1dqGDA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -624,9 +624,9 @@
       }
     },
     "node_modules/@cspell/rpc": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@cspell/rpc/-/rpc-10.0.1.tgz",
-      "integrity": "sha512-axSRKv3zEAmBm66iD/FV/MPmE4/Yf7c3PZiwTW894Yd3iEhtn3KPKeTrqQ2/tDrhB1Z2qTsap/Hue0MK4o5WXg==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@cspell/rpc/-/rpc-10.2.0.tgz",
+      "integrity": "sha512-K8g80OcuhsGqFQvX2kjhgCGs7mOQf5lSeR2Jg34Uq6VQQ/WapJ9pE7CK6R3RKFjhWT8hlrbALiByk9Mj+7GyeQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -634,9 +634,9 @@
       }
     },
     "node_modules/@cspell/strong-weak-map": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-10.0.1.tgz",
-      "integrity": "sha512-lenN1DVyPi8nJLSMSJJ670ddTjyiruLueuSZO1qLcxBqUhgxDt/mALu9N/1m6WdOVcg6m/5cLiZVg2KOo2UzRw==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-10.2.0.tgz",
+      "integrity": "sha512-fBLmVOakQ42Wy+7ZnIdnOSk4/WtJFoNLMEG4yqX/cGML3tIh06PTd9UphwltuwPDCL/tXJQsN/LOY8iLx6hmfw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -644,9 +644,9 @@
       }
     },
     "node_modules/@cspell/url": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@cspell/url/-/url-10.0.1.tgz",
-      "integrity": "sha512-abYYgI29wJhWIfWTYrYuzRYDcHQUQ1N5ylnhxYn1NJnIQMqUWGLbDmt12JABtZ+R6h6UNatQrS7rhP86etvJyQ==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@cspell/url/-/url-10.2.0.tgz",
+      "integrity": "sha512-TIgG/pCkgo3SiayAbV0CorYPdnaNkYWfJFKHhSBTKIdBDwK4YwcbbDlXWGCTJ6gxhhwnrNhcw4jDjz8jejKS4A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -792,9 +792,9 @@
       }
     },
     "node_modules/@eslint/json": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@eslint/json/-/json-2.0.1.tgz",
-      "integrity": "sha512-Thz2j92ceUF3Bq/0TuWb3MWn3Z+Cwc8k5ptF0fakl2D4Mp8mSx07Xr1aQM4R5NoihzarWUdxfOmQ8DesGy4jOg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@eslint/json/-/json-2.1.0.tgz",
+      "integrity": "sha512-Zcg+SXHmdAlo+0ZFwxOvDQye2zxhaFCu/CPdJTsMDSEYZXkX67AWvdwzhI/YdPYNW68Q1Tr1Rv2SsuUZydnjBg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1363,9 +1363,9 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1416,6 +1416,19 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/chalk": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-6.0.0.tgz",
+      "integrity": "sha512-2uNTXIuTTxk7ciZgAU1BQcgnchcG0xXnrs6jzkQfj9SsRa9M2s5zE8WT96hS6KmG4MzWHSrvH43DF1m4XRkrFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/chalk-template": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-1.1.2.tgz",
@@ -1457,13 +1470,13 @@
       }
     },
     "node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/comment-json": {
@@ -1506,33 +1519,33 @@
       }
     },
     "node_modules/cspell": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/cspell/-/cspell-10.0.1.tgz",
-      "integrity": "sha512-Gg6w/flT3fKfl3la62hfTnhtNnDQ+9mU7kUhVqw/axl/Ms4oENw0oJMkWFIoj4f6nL/SDPz7KcPXd2XbkKFNmQ==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/cspell/-/cspell-10.2.0.tgz",
+      "integrity": "sha512-BZaciNlTSZ72IQtju46JlVXyXIMOdoqjU/i1KamisH1uYw1OO4HgG6T0Y8doB99s6v1WJH7W2RL2kqpfq7e1Kw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-json-reporter": "10.0.1",
-        "@cspell/cspell-performance-monitor": "10.0.1",
-        "@cspell/cspell-pipe": "10.0.1",
-        "@cspell/cspell-types": "10.0.1",
-        "@cspell/cspell-worker": "10.0.1",
-        "@cspell/dynamic-import": "10.0.1",
-        "@cspell/url": "10.0.1",
-        "ansi-regex": "^6.2.2",
-        "chalk": "^5.6.2",
+        "@cspell/cspell-json-reporter": "10.2.0",
+        "@cspell/cspell-performance-monitor": "10.2.0",
+        "@cspell/cspell-pipe": "10.2.0",
+        "@cspell/cspell-types": "10.2.0",
+        "@cspell/cspell-worker": "10.2.0",
+        "@cspell/dynamic-import": "10.2.0",
+        "@cspell/url": "10.2.0",
+        "ansi-regex": "^6.3.0",
+        "chalk": "^6.0.0",
         "chalk-template": "^1.1.2",
-        "commander": "^14.0.3",
-        "cspell-config-lib": "10.0.1",
-        "cspell-dictionary": "10.0.1",
-        "cspell-gitignore": "10.0.1",
-        "cspell-glob": "10.0.1",
-        "cspell-io": "10.0.1",
-        "cspell-lib": "10.0.1",
+        "commander": "^15.0.0",
+        "cspell-config-lib": "10.2.0",
+        "cspell-dictionary": "10.2.0",
+        "cspell-gitignore": "10.2.0",
+        "cspell-glob": "10.2.0",
+        "cspell-io": "10.2.0",
+        "cspell-lib": "10.2.0",
         "fast-json-stable-stringify": "^2.1.0",
-        "flatted": "^3.4.2",
-        "semver": "^7.8.1",
-        "tinyglobby": "^0.2.16"
+        "flatted": "^3.4.4",
+        "semver": "^7.8.5",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "cspell": "bin.mjs",
@@ -1546,15 +1559,15 @@
       }
     },
     "node_modules/cspell-config-lib": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/cspell-config-lib/-/cspell-config-lib-10.0.1.tgz",
-      "integrity": "sha512-hMpo/0j6k7pbiqrLDOLJKD2IGP9XwhjKf2miiM6p84Xeo4nyuFZaxxDCQ68R851HSYFrrdltgpoipMbj1h2Tnw==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/cspell-config-lib/-/cspell-config-lib-10.2.0.tgz",
+      "integrity": "sha512-QweJ6dtHm1UkguapTm3Csra6p87HiOmLKiVRAxn75tW9Yojb5fGnqLxErO5sGQZvwgWAqQeT9lrqm3ohvCJjVw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-types": "10.0.1",
+        "@cspell/cspell-types": "10.2.0",
         "comment-json": "^5.0.0",
-        "smol-toml": "^1.6.1",
+        "smol-toml": "^1.8.0",
         "yaml": "^2.9.0"
       },
       "engines": {
@@ -1562,32 +1575,32 @@
       }
     },
     "node_modules/cspell-dictionary": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-10.0.1.tgz",
-      "integrity": "sha512-3cZ659vgsZWkzGQJR/sNqGDVt/OnvTSieLKI76V++4t1bHJfochb9ZrrwsuMsb1VPGiyqClUP1/O6WrefF/FVg==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-10.2.0.tgz",
+      "integrity": "sha512-5r7HBf3nkST6mwsFvRV51i3ETcqFuDQoYK03EqzZYTX4ZLVR/nGrRSOZuFW+d9yU3IKjLWgY14Ab4dDKmBcw7A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-performance-monitor": "10.0.1",
-        "@cspell/cspell-pipe": "10.0.1",
-        "@cspell/cspell-types": "10.0.1",
-        "cspell-trie-lib": "10.0.1",
-        "fast-equals": "^6.0.0"
+        "@cspell/cspell-performance-monitor": "10.2.0",
+        "@cspell/cspell-pipe": "10.2.0",
+        "@cspell/cspell-types": "10.2.0",
+        "cspell-trie-lib": "10.2.0",
+        "fast-equals": "^6.0.2"
       },
       "engines": {
         "node": ">=22.18.0"
       }
     },
     "node_modules/cspell-gitignore": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-10.0.1.tgz",
-      "integrity": "sha512-wN23U61Mx6qPJN3CesOmBU9vnbJ0jQm/ylK0iaVui3CcnO7Zzl5qLu5mPHUzGQGm8yso6qjyxqo16Ho7LpZGOQ==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-10.2.0.tgz",
+      "integrity": "sha512-2/b64Niu5wNlUOW6N7QBRnU8dpnCdvRfZbOgcCO5f5m0OuIbrXTsnrfHJk25w/9M9H2yv2VS8LRKPWuxGXiZpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/url": "10.0.1",
-        "cspell-glob": "10.0.1",
-        "cspell-io": "10.0.1"
+        "@cspell/url": "10.2.0",
+        "cspell-glob": "10.2.0",
+        "cspell-io": "10.2.0"
       },
       "bin": {
         "cspell-gitignore": "bin.mjs"
@@ -1597,28 +1610,28 @@
       }
     },
     "node_modules/cspell-glob": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-10.0.1.tgz",
-      "integrity": "sha512-7bII9J3aSSpZDwhx7w+zfQXbMxHZQ3be0ilUp5bHrsjz6o07v/NqOHMGcwKdPn1sw2dxDz9sv057xE5pqXnSdw==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-10.2.0.tgz",
+      "integrity": "sha512-b6H3zFMkqM5OUVabAvdd4sqyziEo3fFlss73Jn2RsHY2h5PH8gOwM1WsWQOcbDSEn7tj5NsA9a3iETXMkY1thw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/url": "10.0.1",
-        "picomatch": "^4.0.4"
+        "@cspell/url": "10.2.0",
+        "picomatch": "^4.0.7"
       },
       "engines": {
         "node": ">=22.18.0"
       }
     },
     "node_modules/cspell-grammar": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-10.0.1.tgz",
-      "integrity": "sha512-xC9AFYmaI9wsO//a7S5tdDGKGJVD5UEEsTg+Up2fi7lPfXIryisYmV6tePNL1SEg0idYss4ja8LUZ3Mib09BjQ==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-10.2.0.tgz",
+      "integrity": "sha512-CrMM0Qoh9WuputdD08n3qrJKtzoLEZArT7QhMaeZkl58fARYqmx8JgtrE9X0+GSV4Uden0zVa5o4KcdXtXUSAQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-pipe": "10.0.1",
-        "@cspell/cspell-types": "10.0.1"
+        "@cspell/cspell-pipe": "10.2.0",
+        "@cspell/cspell-types": "10.2.0"
       },
       "bin": {
         "cspell-grammar": "bin.mjs"
@@ -1628,48 +1641,48 @@
       }
     },
     "node_modules/cspell-io": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-10.0.1.tgz",
-      "integrity": "sha512-8C2ka07faxflnaqEBO3pektS21XViE/SEHT7F5ZD1ou7FyMR5u3xawTBJSczClfsxLt/WYeztBYrpmGAjmjksw==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-10.2.0.tgz",
+      "integrity": "sha512-UqZcOCH+W9DhcjQGRiKJIwQaeNLGA+PKBHVmw4hvmBvuWGCH7uSiHuOeO+WrvJbolFDfZ9f7gV5ItmITgSANHg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-service-bus": "10.0.1",
-        "@cspell/url": "10.0.1"
+        "@cspell/cspell-service-bus": "10.2.0",
+        "@cspell/url": "10.2.0"
       },
       "engines": {
         "node": ">=22.18.0"
       }
     },
     "node_modules/cspell-lib": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-10.0.1.tgz",
-      "integrity": "sha512-RpsIPiLzc4/YMW8BMRKpyJ81x439qjYWcqgdKeXnMkbKM88J9PexzutfFf/4v97v96KzfNitEzMpbI0uj8OeUg==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-10.2.0.tgz",
+      "integrity": "sha512-uIU4RtUzodzlS39O26Q1g0AxdHNB7CndkaN40Ekmb19kKrOf49umsXhRhdzrYc/uQ9dsp4AFp/mQI5Yc1MK1NA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-bundled-dicts": "10.0.1",
-        "@cspell/cspell-performance-monitor": "10.0.1",
-        "@cspell/cspell-pipe": "10.0.1",
-        "@cspell/cspell-resolver": "10.0.1",
-        "@cspell/cspell-types": "10.0.1",
-        "@cspell/dynamic-import": "10.0.1",
-        "@cspell/filetypes": "10.0.1",
-        "@cspell/rpc": "10.0.1",
-        "@cspell/strong-weak-map": "10.0.1",
-        "@cspell/url": "10.0.1",
-        "cspell-config-lib": "10.0.1",
-        "cspell-dictionary": "10.0.1",
-        "cspell-glob": "10.0.1",
-        "cspell-grammar": "10.0.1",
-        "cspell-io": "10.0.1",
-        "cspell-trie-lib": "10.0.1",
+        "@cspell/cspell-bundled-dicts": "10.2.0",
+        "@cspell/cspell-performance-monitor": "10.2.0",
+        "@cspell/cspell-pipe": "10.2.0",
+        "@cspell/cspell-resolver": "10.2.0",
+        "@cspell/cspell-types": "10.2.0",
+        "@cspell/dynamic-import": "10.2.0",
+        "@cspell/filetypes": "10.2.0",
+        "@cspell/rpc": "10.2.0",
+        "@cspell/strong-weak-map": "10.2.0",
+        "@cspell/url": "10.2.0",
+        "cspell-config-lib": "10.2.0",
+        "cspell-dictionary": "10.2.0",
+        "cspell-glob": "10.2.0",
+        "cspell-grammar": "10.2.0",
+        "cspell-io": "10.2.0",
+        "cspell-trie-lib": "10.2.0",
         "env-paths": "^4.0.0",
         "gensequence": "^8.0.8",
         "import-fresh": "^4.0.0",
         "resolve-from": "^5.0.0",
-        "vscode-languageserver-textdocument": "^1.0.12",
-        "vscode-uri": "^3.1.0",
+        "vscode-languageserver-textdocument": "^1.0.14",
+        "vscode-uri": "^3.2.0",
         "xdg-basedir": "^5.1.0"
       },
       "engines": {
@@ -1677,29 +1690,16 @@
       }
     },
     "node_modules/cspell-trie-lib": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-10.0.1.tgz",
-      "integrity": "sha512-BFvhalSkRQFjKrZ//FKK7fRGrZFpifnxB5AwCkzsIsBZqicsfafcQ1xP21qpb0QqyV/IomjNgviG+tRJs+0rMw==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-10.2.0.tgz",
+      "integrity": "sha512-lvEfGc/SfNfkdq9LZYQENDMuPoILsLwo2o4QHqdyic65MvmL1fZLi77O/qgSJ4aKgVja0/A8cbsdtKnFuruHbw==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=22.18.0"
       },
       "peerDependencies": {
-        "@cspell/cspell-types": "10.0.1"
-      }
-    },
-    "node_modules/cspell/node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
+        "@cspell/cspell-types": "10.2.0"
       }
     },
     "node_modules/debug": {
@@ -1795,9 +1795,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.8.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.0.tgz",
-      "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.9.1.tgz",
+      "integrity": "sha512-9VaAkDURekixUQJy0oJYl2DcN6oKMfxay7XzaGYAWQwsb6qfKf+x76R2k1L8kb1boc+FyCAaTA9GmiKaaiaF+A==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -2145,9 +2145,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
-      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
+      "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
       "dev": true,
       "license": "ISC"
     },
@@ -2219,9 +2219,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.9.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.9.0.tgz",
-      "integrity": "sha512-m/MvAW61QVU5VDNF1Vj8axt016h8w7L5TU1e9zlab7XIttAT2YAlCwl75K1fOqvMM9apmD7lbCIRhpfkhmxhCg==",
+      "version": "17.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.12.0.tgz",
+      "integrity": "sha512-cezEd/DTyyht9cvSSURyygXPfy04GtWO/5e6ZPvH7fCtjKz9PYOmuawphw1Ctd1f6C+5JypXfGD7ahNMXvevBA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2413,15 +2413,15 @@
       }
     },
     "node_modules/lint-staged": {
-      "version": "17.3.0",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.3.0.tgz",
-      "integrity": "sha512-woZS3vNe3UKqBaLPvbLOtKRY4tLANpWQhom12MGWqC8Mh1lCOO+WgSwmX2amjJAqTY9BkXYW87fCUH5H9Ph6xw==",
+      "version": "17.4.1",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.4.1.tgz",
+      "integrity": "sha512-FmJeudcalbSfg1du+JCfvi5vS6Qt08KgbfLWiHinbef+2JJwUZwAWVoaO1AcJVUTWPfk0t30PMQNwPAeCzYQ+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "picomatch": "^4.0.5",
+        "picomatch": "^4.0.7",
         "string-argv": "^0.3.2",
-        "tinyexec": "^1.2.4"
+        "tinyexec": "^1.3.0"
       },
       "bin": {
         "lint-staged": "bin/lint-staged.js"
@@ -3457,9 +3457,9 @@
       }
     },
     "node_modules/picomatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3562,9 +3562,9 @@
       }
     },
     "node_modules/smol-toml": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.7.0.tgz",
-      "integrity": "sha512-aqVvWoyO21L23mb+drl4RmMXbf6N7FdHjAhTRA9ZBL7apWBgfWC16KjrASI+1p9GAroljyMHj6fK67i0UiTNvQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.8.0.tgz",
+      "integrity": "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -3595,9 +3595,9 @@
       }
     },
     "node_modules/tinyexec": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
-      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3762,16 +3762,16 @@
       }
     },
     "node_modules/vscode-languageserver-textdocument": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
-      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.14.tgz",
+      "integrity": "sha512-EQyqJMi552E4ZTf46izQ4Fj6XquqxCySR3J5ZSD1SisMf6RfpeOWHxGBE8Gr6V0/3GHIGdAzDn8F8+1nTGCnoQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/vscode-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
-      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.2.0.tgz",
+      "integrity": "sha512-m2gXo3bn0G1kT9InzMf07fTbqMbGtyckj3bH5ktLO+1Ssv+yiATZ4dhwaQv9UZWxJh6E9IFGnQyjgWVDWVBDrg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -33,14 +33,14 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@eslint/json": "^2.0.1",
+    "@eslint/json": "^2.1.0",
     "@eslint/markdown": "^8.0.3",
-    "cspell": "^10.0.1",
-    "eslint": "^10.8.0",
+    "cspell": "^10.2.0",
+    "eslint": "^10.9.1",
     "eslint-plugin-import-x": "^4.17.1",
-    "globals": "^17.9.0",
+    "globals": "^17.12.0",
     "husky": "^9.1.7",
-    "lint-staged": "^17.3.0",
+    "lint-staged": "^17.4.1",
     "prettier": "^3.9.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mmm-motiondetector",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "a motion detector module for MagicMirror",
   "author": "rejas@github.com",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bumps package version to 1.8.1
- Updates CHANGELOG.md with the 1.8.1 release entry, covering the CI job rename (`run-lint` → `lint-and-test`, #114) and dev dependency updates (#120, #125) since 1.8.0

## Test plan
- [x] `node --run lint` (eslint + prettier)
- [x] `node --run test:spelling` (cspell)
- [x] `node --run test:unit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)